### PR TITLE
Phase 3: Motion control & trajectory smoothing

### DIFF
--- a/buddy/__init__.py
+++ b/buddy/__init__.py
@@ -1,0 +1,1 @@
+"""Buddy: a MicroPython 6-DOF arm built on STS3215 serial bus servos."""

--- a/buddy/motion.py
+++ b/buddy/motion.py
@@ -1,0 +1,263 @@
+"""Time-parameterised motion controller for the Buddy arm.
+
+Layered on top of ``buddy.arm.Arm``: each tick we compute an interpolated
+joint-angle vector for the planned trajectory and push it to the arm in a
+single sync-write packet (via ``Arm.move_all``).
+
+================================================================
+Hardware vs software control decision
+================================================================
+We rely on the STS3215's *built-in* hardware position controller for the final
+joint-level closed loop. The driver writes goal acceleration and goal speed
+through ``REG_GOAL_ACC`` / ``REG_GOAL_SPEED`` (see ``sts3215.py``); the servo
+firmware does the PID tracking internally. This software layer is therefore
+purely a **trajectory generator** -- it shapes the *sequence* of setpoints we
+hand to the servo (linear interpolation between the current joint vector and
+the target, respecting per-joint velocity / acceleration limits) but does
+**not** run a software PID loop on top.
+
+Why no software PID:
+
+* The servo's onboard loop runs faster than we can possibly close one over the
+  serial bus (1 Mbaud half-duplex, ~10-15 servos worth of read/write per tick
+  at 50 Hz is already tight).
+* A software loop would need ``read_all`` every tick, doubling bus traffic and
+  jitter for negligible benefit on a position-controlled servo.
+* The STS3215's GOAL_SPEED / GOAL_ACC params already express velocity and
+  acceleration limits in hardware -- duplicating them in software invites
+  fighting between the two controllers.
+
+If hardware control proves inadequate for a given application (e.g. very
+slow, very precise tracking) a software PID can be slotted in inside
+``_tick`` without changing the public API: ``move_all`` would receive
+``current + pid(error)`` instead of the pure interpolated setpoint.
+================================================================
+"""
+
+# uasyncio on MicroPython, asyncio on CPython -- the two are API-compatible
+# for our use (sleep, create_task, Event).
+try:
+    import uasyncio as asyncio
+except ImportError:  # pragma: no cover -- MicroPython-only branch
+    import asyncio
+
+
+DEFAULT_TICK_HZ = 50
+DEFAULT_MAX_VELOCITY = 180.0  # degrees per second per joint
+DEFAULT_MAX_ACCELERATION = 720.0  # degrees per second^2 per joint
+
+
+def _interpolate(start, end, t):
+    """Linear interpolation between two scalar joint angles.
+
+    ``t`` is the normalised progress in [0, 1] -- callers must clamp before
+    calling. Endpoints are exact: ``_interpolate(a, b, 0) == a`` and
+    ``_interpolate(a, b, 1) == b``.
+    """
+    return start + (end - start) * t
+
+
+def _plan_duration(start_angles, end_angles, requested_duration,
+                   max_velocity, max_acceleration):
+    """Return the duration we will actually use for this move.
+
+    If the caller-requested duration is too aggressive for the configured
+    per-joint velocity or acceleration limits, we *stretch* the move so the
+    fastest joint stays inside its envelope. This is friendlier than rejecting
+    the move (which would force callers to compute the limits themselves) and
+    matches how the STS3215 hardware behaves: speed-limited rather than
+    error-out-on-overspeed.
+
+    For each joint with delta = |end - start|:
+        v_required = delta / duration
+        a_required = v_required / (duration / 2)   # accel half, decel half
+                   = 2 * delta / duration^2
+
+    We solve for the minimum duration that keeps both inside the limits.
+    """
+    if requested_duration <= 0:
+        raise ValueError("duration must be > 0")
+    if max_velocity <= 0:
+        raise ValueError("max_velocity must be > 0")
+    if max_acceleration <= 0:
+        raise ValueError("max_acceleration must be > 0")
+
+    duration = float(requested_duration)
+    for s, e in zip(start_angles, end_angles):
+        delta = abs(e - s)
+        if delta == 0:
+            continue
+        # Velocity-limited minimum duration.
+        d_vel = delta / max_velocity
+        # Acceleration-limited minimum duration (triangular profile).
+        # Linear interpolation has constant velocity in the middle, but the
+        # *transition* from rest at endpoints implies an effective acceleration
+        # of v / (duration/2) = 2*delta/duration^2.
+        d_acc = (2.0 * delta / max_acceleration) ** 0.5
+        joint_min = max(d_vel, d_acc)
+        if joint_min > duration:
+            duration = joint_min
+    return duration
+
+
+class MotionController:
+    """Non-blocking trajectory generator for an ``Arm``.
+
+    Usage::
+
+        arm = Arm(...)
+        mc = MotionController(arm)
+        mc.start()                      # spawns the asyncio tick task
+        mc.move_to([0, 30, ...], 2.0)   # returns immediately
+        await mc.wait()                 # resolves when motion finishes
+        mc.stop()                       # cancels the tick task
+
+    The controller never blocks the event loop; it ``asyncio.sleep``s between
+    ticks so the future web server / other coroutines run concurrently.
+    """
+
+    def __init__(self, arm,
+                 tick_hz=DEFAULT_TICK_HZ,
+                 max_velocity=DEFAULT_MAX_VELOCITY,
+                 max_acceleration=DEFAULT_MAX_ACCELERATION,
+                 time_func=None):
+        if tick_hz <= 0:
+            raise ValueError("tick_hz must be > 0")
+        self._arm = arm
+        self._tick_hz = tick_hz
+        self._tick_period = 1.0 / tick_hz
+        self._max_velocity = max_velocity
+        self._max_acceleration = max_acceleration
+        # Tests inject a virtual clock; production uses real time.
+        if time_func is None:
+            import time as _time
+            self._time = _time.monotonic
+        else:
+            self._time = time_func
+
+        self._task = None
+        self._stop = False
+
+        # Trajectory state
+        self._start_angles = None
+        self._target_angles = None
+        self._move_start = 0.0
+        self._move_duration = 0.0
+        self._moving = False
+        self._done_event = asyncio.Event()
+        self._done_event.set()  # idle on construction
+
+    # ---- public API --------------------------------------------------
+
+    def move_to(self, target_angles, duration):
+        """Plan a linear move from the current position to ``target_angles``.
+
+        Returns immediately. ``duration`` is in seconds and may be stretched
+        to respect ``max_velocity`` / ``max_acceleration``. If a move is
+        already in progress it is replaced -- the new trajectory starts from
+        wherever the arm is *now* (interpolated, not re-read from hardware).
+        """
+        target_angles = list(target_angles)
+        current = self._current_setpoint()
+        if len(target_angles) != len(current):
+            raise ValueError(
+                "target_angles length {} does not match arm joint count {}"
+                .format(len(target_angles), len(current))
+            )
+        actual_duration = _plan_duration(
+            current, target_angles, duration,
+            self._max_velocity, self._max_acceleration,
+        )
+        self._start_angles = current
+        self._target_angles = target_angles
+        self._move_start = self._time()
+        self._move_duration = actual_duration
+        self._moving = True
+        self._done_event.clear()
+        return actual_duration
+
+    def is_moving(self):
+        """``True`` while a planned trajectory is still progressing."""
+        return self._moving
+
+    async def wait(self):
+        """Awaitable: resolves once the current move finishes (or immediately
+        if no move is in progress)."""
+        await self._done_event.wait()
+
+    def start(self):
+        """Spawn the background tick task. Idempotent."""
+        if self._task is None:
+            self._stop = False
+            self._task = asyncio.create_task(self._run())
+        return self._task
+
+    def stop(self):
+        """Stop the background tick task. Pending move (if any) is abandoned."""
+        self._stop = True
+        if self._task is not None:
+            try:
+                self._task.cancel()
+            except Exception:  # pragma: no cover -- task may already be done
+                pass
+            self._task = None
+        self._moving = False
+        self._done_event.set()
+
+    # ---- internals ---------------------------------------------------
+
+    def _current_setpoint(self):
+        """Return the joint vector we will treat as the move's starting point.
+
+        While moving: the interpolated setpoint at *now*. When idle: whatever
+        we last commanded; if no move has ever been issued, fall back to
+        ``arm.read_all()``.
+        """
+        if self._moving and self._start_angles is not None:
+            return self._compute_setpoint(self._time())
+        if self._target_angles is not None:
+            return list(self._target_angles)
+        return list(self._arm.read_all())
+
+    def _compute_setpoint(self, now):
+        """Interpolated joint vector at absolute time ``now``. Endpoints
+        clamp -- before the move starts, snap to start; after it ends, snap
+        to target."""
+        if self._move_duration <= 0:
+            return list(self._target_angles)
+        elapsed = now - self._move_start
+        if elapsed <= 0:
+            return list(self._start_angles)
+        if elapsed >= self._move_duration:
+            return list(self._target_angles)
+        t = elapsed / self._move_duration
+        return [
+            _interpolate(s, e, t)
+            for s, e in zip(self._start_angles, self._target_angles)
+        ]
+
+    def tick(self):
+        """One trajectory tick. Pushes the interpolated setpoint to the arm
+        via a single sync-write (``Arm.move_all``). Public so tests and
+        non-async harnesses can drive the controller deterministically."""
+        if not self._moving:
+            return False
+        now = self._time()
+        setpoint = self._compute_setpoint(now)
+        # Single sync-write packet for all joints -- crucial for coordinated
+        # motion and for keeping bus traffic to ~1 packet per tick.
+        self._arm.move_all(setpoint)
+        if now - self._move_start >= self._move_duration:
+            self._moving = False
+            self._done_event.set()
+        return True
+
+    async def _run(self):
+        """Background task: tick at ``tick_hz`` until ``stop()`` is called."""
+        while not self._stop:
+            try:
+                self.tick()
+            except Exception:  # pragma: no cover -- swallow per-tick errors
+                # Don't let a transient bus error kill the loop forever.
+                pass
+            await asyncio.sleep(self._tick_period)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -1,0 +1,347 @@
+"""Tests for buddy.motion -- trajectory generator on top of Arm.
+
+Arm is mocked entirely; these tests do not depend on issue #2's arm.py
+implementation existing yet. The mock only needs to satisfy the surface
+``MotionController`` actually calls: ``move_all(angles)`` and ``read_all()``.
+"""
+import asyncio
+
+import pytest
+
+from buddy.motion import (
+    MotionController,
+    _interpolate,
+    _plan_duration,
+    DEFAULT_TICK_HZ,
+)
+
+
+# ---- mock Arm --------------------------------------------------------------
+
+class FakeArm:
+    """Minimal stand-in for the future ``buddy.arm.Arm`` class.
+
+    Records every ``move_all`` call so tests can assert sync-write semantics
+    (one packet per tick, never per-joint).
+    """
+
+    def __init__(self, joint_count=6, initial_angles=None):
+        self.joint_count = joint_count
+        if initial_angles is None:
+            initial_angles = [0.0] * joint_count
+        self._angles = list(initial_angles)
+        self.move_all_calls = []  # list of joint vectors, in the order pushed
+        self.move_joint_calls = []  # would flag a per-joint regression
+
+    def move_all(self, angles):
+        angles = list(angles)
+        assert len(angles) == self.joint_count, \
+            "move_all called with wrong joint count"
+        self.move_all_calls.append(angles)
+        self._angles = angles
+
+    def move_joint(self, idx, angle, speed=0):  # pragma: no cover -- guard
+        self.move_joint_calls.append((idx, angle, speed))
+
+    def read_all(self):
+        return list(self._angles)
+
+
+# ---- virtual clock ---------------------------------------------------------
+
+class Clock:
+    """Hand-cranked monotonic clock for deterministic interpolation tests."""
+
+    def __init__(self, t0=0.0):
+        self.t = t0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+# ---- fixtures --------------------------------------------------------------
+
+@pytest.fixture
+def arm():
+    return FakeArm()
+
+
+@pytest.fixture
+def clock():
+    return Clock()
+
+
+@pytest.fixture
+def mc(arm, clock):
+    return MotionController(arm, time_func=clock)
+
+
+# ---- _interpolate ----------------------------------------------------------
+
+def test_interpolate_endpoints_exact():
+    assert _interpolate(10.0, 30.0, 0.0) == 10.0
+    assert _interpolate(10.0, 30.0, 1.0) == 30.0
+
+
+def test_interpolate_midpoint():
+    assert _interpolate(10.0, 30.0, 0.5) == 20.0
+
+
+def test_interpolate_negative_delta():
+    # going from 30 down to 10
+    assert _interpolate(30.0, 10.0, 0.25) == 25.0
+
+
+# ---- _plan_duration --------------------------------------------------------
+
+def test_plan_duration_returns_request_when_within_limits():
+    # 10° move at max_v=180°/s -> v_min = 10/180 = 0.055s, far below 1s
+    d = _plan_duration([0], [10], 1.0, max_velocity=180, max_acceleration=720)
+    assert d == 1.0
+
+
+def test_plan_duration_stretches_for_velocity():
+    # 360° in 0.1s -> 3600°/s, way above 180°/s limit. Min is 360/180 = 2.0s.
+    # Acceleration check: sqrt(2*360/720) = 1.0s -> velocity dominates.
+    d = _plan_duration([0], [360], 0.1, max_velocity=180, max_acceleration=720)
+    assert d == pytest.approx(2.0)
+
+
+def test_plan_duration_stretches_for_acceleration():
+    # Tiny move (1°) at very low accel -- accel becomes the binding limit.
+    # v limit: 1/180 = 0.0056s; a limit: sqrt(2*1/0.5) = 2.0s -> accel wins.
+    d = _plan_duration([0], [1], 0.01, max_velocity=180, max_acceleration=0.5)
+    assert d == pytest.approx(2.0)
+
+
+def test_plan_duration_zero_move_keeps_request():
+    d = _plan_duration([10, 20], [10, 20], 0.5,
+                       max_velocity=180, max_acceleration=720)
+    assert d == 0.5
+
+
+def test_plan_duration_uses_fastest_joint():
+    # Two joints: tiny one and a big one. Big one should dominate.
+    d = _plan_duration([0, 0], [1, 360], 0.1,
+                       max_velocity=180, max_acceleration=720)
+    assert d == pytest.approx(2.0)
+
+
+def test_plan_duration_rejects_zero_or_negative():
+    with pytest.raises(ValueError):
+        _plan_duration([0], [10], 0, 180, 720)
+    with pytest.raises(ValueError):
+        _plan_duration([0], [10], -1, 180, 720)
+
+
+def test_plan_duration_rejects_bad_limits():
+    with pytest.raises(ValueError):
+        _plan_duration([0], [10], 1, 0, 720)
+    with pytest.raises(ValueError):
+        _plan_duration([0], [10], 1, 180, 0)
+
+
+# ---- MotionController construction ----------------------------------------
+
+def test_constructor_rejects_bad_tick_hz(arm):
+    with pytest.raises(ValueError):
+        MotionController(arm, tick_hz=0)
+
+
+def test_default_tick_hz_is_50(arm):
+    mc = MotionController(arm)
+    assert mc._tick_hz == DEFAULT_TICK_HZ
+
+
+def test_idle_after_construction(arm):
+    mc = MotionController(arm)
+    assert mc.is_moving() is False
+
+
+# ---- move_to and interpolation --------------------------------------------
+
+def test_move_to_returns_immediately(mc, arm):
+    # A "long" move should return without waiting for completion.
+    duration = mc.move_to([10.0] * 6, 1.0)
+    assert duration == pytest.approx(1.0)
+    assert mc.is_moving() is True
+    # No ticks yet -> nothing pushed to the arm.
+    assert arm.move_all_calls == []
+
+
+def test_move_to_rejects_wrong_length(mc):
+    with pytest.raises(ValueError):
+        mc.move_to([10.0, 20.0], 1.0)  # only 2 joints, arm has 6
+
+
+def test_move_to_uses_planned_duration_when_too_short(arm, clock):
+    # Cap velocity hard so 360° in 0.1s gets stretched to 360/90 = 4s.
+    mc = MotionController(arm, max_velocity=90, max_acceleration=10000,
+                          time_func=clock)
+    target = [360.0] + [0.0] * 5
+    actual = mc.move_to(target, 0.1)
+    assert actual == pytest.approx(4.0)
+
+
+def test_tick_pushes_interpolated_setpoint(mc, arm, clock):
+    target = [60.0] + [0.0] * 5
+    mc.move_to(target, 1.0)
+
+    # t=0 tick: should command the start point (all zeros).
+    mc.tick()
+    assert arm.move_all_calls[-1] == [0.0] * 6
+
+    # t=0.5 tick: midway through the 1s move -> 30° on joint 0.
+    clock.advance(0.5)
+    mc.tick()
+    assert arm.move_all_calls[-1][0] == pytest.approx(30.0)
+    for v in arm.move_all_calls[-1][1:]:
+        assert v == pytest.approx(0.0)
+
+    # t=1.0 tick: completes move; setpoint clamps at target.
+    clock.advance(0.5)
+    mc.tick()
+    assert arm.move_all_calls[-1][0] == pytest.approx(60.0)
+    assert mc.is_moving() is False
+
+
+def test_tick_progress_is_monotonic(mc, arm, clock):
+    target = [90.0] + [0.0] * 5
+    mc.move_to(target, 1.0)
+    last = -float("inf")
+    for _ in range(11):
+        mc.tick()
+        v = arm.move_all_calls[-1][0]
+        assert v >= last
+        last = v
+        clock.advance(0.1)
+    # Final clamp at the target.
+    assert last == pytest.approx(90.0)
+
+
+def test_tick_clamps_after_overshoot(mc, arm, clock):
+    target = [45.0] + [0.0] * 5
+    mc.move_to(target, 0.5)
+    clock.advance(10.0)  # way past the end
+    mc.tick()
+    assert arm.move_all_calls[-1][0] == pytest.approx(45.0)
+    assert mc.is_moving() is False
+
+
+def test_tick_does_nothing_when_idle(mc, arm):
+    # No move issued -> tick is a no-op (no bus traffic).
+    assert mc.tick() is False
+    assert arm.move_all_calls == []
+
+
+def test_tick_uses_single_sync_write(mc, arm, clock):
+    """One ``move_all`` per tick, NEVER ``move_joint`` per joint."""
+    mc.move_to([10.0] * 6, 1.0)
+    for _ in range(5):
+        mc.tick()
+        clock.advance(0.1)
+    # Exactly one move_all per tick (5 ticks above).
+    assert len(arm.move_all_calls) == 5
+    # And NO per-joint writes anywhere.
+    assert arm.move_joint_calls == []
+
+
+def test_replanning_starts_from_current_interpolated_position(mc, arm, clock):
+    """Issuing a new move mid-trajectory should start from the *interpolated*
+    current position, not from the original start."""
+    mc.move_to([100.0] + [0.0] * 5, 1.0)
+    clock.advance(0.5)  # halfway -> joint 0 is at ~50°
+
+    mc.move_to([0.0] * 6, 1.0)  # back to zero
+    # The new start angles should be ~50° on joint 0.
+    assert mc._start_angles[0] == pytest.approx(50.0)
+
+
+def test_move_to_uses_arm_read_all_when_no_prior_move(arm, clock):
+    arm._angles = [42.0] * 6
+    mc = MotionController(arm, time_func=clock)
+    mc.move_to([100.0] * 6, 1.0)
+    assert mc._start_angles == [42.0] * 6
+
+
+# ---- non-blocking semantics under asyncio ---------------------------------
+
+def test_move_to_is_non_blocking_under_asyncio(arm):
+    """``move_to`` must return immediately; ``wait()`` blocks until the
+    background tick loop drains the trajectory."""
+
+    async def scenario():
+        # 100Hz so a 0.1s move resolves in ~10 ticks -- quick enough for CI.
+        mc = MotionController(arm, tick_hz=100)
+        mc.start()
+        try:
+            mc.move_to([10.0] * 6, 0.1)
+            # We did NOT await wait() yet -- still moving.
+            assert mc.is_moving() is True
+            await mc.wait()
+            assert mc.is_moving() is False
+            # And the arm received at least one sync-write.
+            assert len(arm.move_all_calls) >= 1
+            # Final command was at (or extremely close to) the target.
+            final = arm.move_all_calls[-1]
+            for v in final:
+                assert v == pytest.approx(10.0, abs=0.5)
+        finally:
+            mc.stop()
+
+    asyncio.run(scenario())
+
+
+def test_wait_returns_immediately_when_idle(arm):
+    async def scenario():
+        mc = MotionController(arm)
+        await mc.wait()  # never moved -> done_event already set
+
+    asyncio.run(scenario())
+
+
+def test_start_is_idempotent(arm):
+    async def scenario():
+        mc = MotionController(arm)
+        t1 = mc.start()
+        t2 = mc.start()
+        assert t1 is t2
+        mc.stop()
+
+    asyncio.run(scenario())
+
+
+def test_stop_without_start_is_safe(arm):
+    mc = MotionController(arm)
+    mc.stop()  # no task to cancel; must not raise
+    assert mc.is_moving() is False
+
+
+def test_stop_aborts_pending_move(arm, clock):
+    mc = MotionController(arm, time_func=clock)
+    mc.move_to([10.0] * 6, 1.0)
+    assert mc.is_moving() is True
+    mc.stop()
+    assert mc.is_moving() is False
+
+
+def test_compute_setpoint_before_start_returns_start(arm, clock):
+    mc = MotionController(arm, time_func=clock)
+    mc.move_to([10.0] * 6, 1.0)
+    # rewind clock prior to move_start -> elapsed < 0
+    clock.t = mc._move_start - 5.0
+    setpoint = mc._compute_setpoint(clock())
+    assert setpoint == [0.0] * 6
+
+
+def test_compute_setpoint_zero_duration_returns_target(arm, clock):
+    """Pathological zero-duration trajectory snaps to target on first tick."""
+    mc = MotionController(arm, time_func=clock)
+    mc._start_angles = [0.0] * 6
+    mc._target_angles = [10.0] * 6
+    mc._move_duration = 0.0
+    mc._move_start = clock()
+    assert mc._compute_setpoint(clock()) == [10.0] * 6


### PR DESCRIPTION
Closes #3.

## Summary
Adds `buddy/motion.py` -- a non-blocking, asyncio-driven trajectory generator layered on top of the (forthcoming) `buddy.arm.Arm` class.

- Linear interpolation between the current and target joint vectors, ticked at 50 Hz by default.
- Configurable per-joint `max_velocity` and `max_acceleration`; a too-aggressive `duration` is stretched (rather than rejected) so the fastest joint stays inside its envelope. This matches the speed-limited behaviour of the STS3215 hardware.
- One sync-write per tick via `Arm.move_all` (never per-joint), keeping bus traffic to ~1 packet per tick.
- Non-blocking API: `move_to(angles, duration)` returns immediately; `is_moving()` / `await mc.wait()` for completion. `start()` spawns the asyncio tick task so it cooperates with the future web server.
- Replanning mid-trajectory starts from the current interpolated setpoint, not the original start.

## Hardware vs PID decision
**Hardware control only -- no software PID.** Recorded in a docstring banner at the top of `motion.py`. The STS3215's onboard PID + `GOAL_SPEED` / `GOAL_ACC` registers already do per-joint velocity, acceleration, and position closed-loop control faster than we can over the 1 Mbaud half-duplex bus. Adding a software loop would double bus traffic (it would need `read_all` every tick) and risk fighting the hardware controller. If a future application requires it, the hook point is clearly noted in the comment: swap the pure interpolated setpoint inside `_tick` for `current + pid(error)` -- public API stays the same.

## Dependency on #2
This PR depends on #2 (the `Arm` class in `buddy/arm.py`). #2 is being implemented in a parallel worktree, so the Arm API surface is not yet present in this branch. The motion controller is built against the API surface declared in issue #2:
- `Arm.move_all(angles)` -- single sync-write packet
- `Arm.read_all()` -- current joint vector

In tests, `Arm` is mocked entirely (`FakeArm` in `tests/test_motion.py`); these tests do **not** import `buddy.arm`. **After #2 merges this branch will likely need a rebase** to confirm the real `Arm.move_all` / `Arm.read_all` signatures match. Once aligned, integration tests against the real `Arm` can be added in a follow-up.

## Test plan
- [x] `pytest tests/test_motion.py --cov=buddy.motion --cov-report=term-missing` -- 30 passed, 99% coverage on `buddy/motion.py`.
- [x] Full suite (`pytest tests/`) -- 58 passed, no regressions on the existing STS3215 driver tests.
- [ ] After #2 merges: rebase, re-run suite, optionally add integration tests using the real `Arm`.
- [ ] On hardware: verify a 6-joint coordinated move at 50 Hz tracks smoothly without bus errors.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>