### PR TITLE
Phase 4: Forward & inverse kinematics

### DIFF
--- a/buddy/__init__.py
+++ b/buddy/__init__.py
@@ -1,5 +1,25 @@
 """Buddy: high-level robotics package built on top of the STS3215 driver."""
 
 from .arm import Arm, JointConfig, DEFAULT_JOINT_CONFIGS
+from .kinematics import (
+    DEFAULT_DH_PARAMS,
+    DEFAULT_LINKS,
+    KinematicsError,
+    NUM_JOINTS,
+    dh_table,
+    forward,
+    inverse,
+)
 
-__all__ = ["Arm", "JointConfig", "DEFAULT_JOINT_CONFIGS"]
+__all__ = [
+    "Arm",
+    "JointConfig",
+    "DEFAULT_JOINT_CONFIGS",
+    "DEFAULT_DH_PARAMS",
+    "DEFAULT_LINKS",
+    "KinematicsError",
+    "NUM_JOINTS",
+    "dh_table",
+    "forward",
+    "inverse",
+]

--- a/buddy/kinematics.py
+++ b/buddy/kinematics.py
@@ -1,0 +1,399 @@
+"""Forward and inverse kinematics for the Buddy 6-servo arm.
+
+Approach
+========
+The default Buddy arm has six servos but only five are used to position
+the tool tip — the sixth is a parallel-jaw gripper.  The first five joints
+form the standard "5-DoF hobby arm" topology::
+
+    base (yaw)  ->  shoulder (pitch)  ->  elbow (pitch)
+                ->  wrist (pitch)     ->  wrist_rot (roll)
+
+With this geometry the analytical solution is straightforward and *much*
+faster than a numeric (Jacobian / damped-least-squares) iteration on a
+microcontroller.  We therefore use a closed-form geometric IK:
+
+    1. The base yaw is recovered directly from ``atan2(y, x)``.
+    2. The shoulder/elbow form a planar 2-link manipulator in the
+       vertical plane that rotates with the base; it is solved with the
+       law of cosines.
+    3. The wrist pitch is set from the desired *tool pitch* (angle of the
+       gripper approach vector relative to horizontal).
+    4. The wrist roll is the requested ``tool_roll`` passed through.
+
+A 5-DoF arm cannot independently command all three orientation degrees
+of freedom.  The pose interface is therefore a 5-tuple
+``(x, y, z, tool_pitch_deg, tool_roll_deg)`` and ``forward()`` returns
+the same shape so that ``forward → inverse`` round-trips are exact
+(modulo float precision).
+
+Geometry config
+---------------
+:data:`DEFAULT_LINKS` holds the five physical link parameters used for
+both FK and IK.  This is intentionally simpler than a full DH table —
+the arm topology is fixed (revolute joints with the orientations
+described above), so we only need lengths and offsets:
+
+* ``base_height``   – vertical offset from the base mount to the
+  shoulder joint.
+* ``upper_arm``     – length from the shoulder to the elbow.
+* ``forearm``       – length from the elbow to the wrist pitch axis.
+* ``wrist_offset``  – axial offset between the wrist pitch axis and the
+  wrist roll axis (often 0 for clean spherical-wrist designs).
+* ``tool_length``   – distance from the wrist roll axis to the tool tip
+  (gripper finger contact point).
+
+A DH parameter view (:func:`dh_table`) is provided for compatibility
+with downstream tools that expect classical Denavit-Hartenberg input.
+
+All distances are millimetres.  Default values are *placeholders*; real
+hardware requires measurement (see README).
+
+Sentinel / error handling
+-------------------------
+* Out-of-reach Cartesian targets raise :class:`KinematicsError` with a
+  message naming the failing constraint ("target too far",
+  "target too close", ...).
+* Joint-limit violations raise :class:`KinematicsError`; the caller can
+  catch and decide whether to clamp or refuse.
+* Singular targets on the vertical base axis are detected and a
+  documented sentinel of ``base = 0`` is returned so the arm does not
+  spin unpredictably.
+
+Units
+-----
+* All Cartesian coordinates: millimetres.
+* All joint and pose angles: degrees, matching :class:`buddy.arm.JointConfig`.
+"""
+
+import math
+
+
+# ---------------------------------------------------------------------------
+# Geometry config
+# ---------------------------------------------------------------------------
+#
+# Default link lengths (mm).  These are placeholder values for a generic
+# 5-DoF hobby arm; real hardware requires measurement.
+
+DEFAULT_LINKS = {
+    "base_height":  100.0,   # base mount to shoulder pitch axis
+    "upper_arm":    120.0,   # shoulder to elbow
+    "forearm":      120.0,   # elbow to wrist pitch axis
+    "wrist_offset":   0.0,   # wrist pitch to wrist roll axis (axial)
+    "tool_length":   60.0,   # wrist roll to tool tip
+}
+
+
+def dh_table(links=DEFAULT_LINKS):
+    """Return a classical Denavit-Hartenberg parameter table for the chain.
+
+    Each row is ``(a, alpha, d, theta_offset)`` in standard DH convention.
+    The chain is::
+
+        joint 1 (base yaw)   : a=0,                alpha=+pi/2, d=base_height
+        joint 2 (shoulder)   : a=upper_arm,        alpha=0,     d=0
+        joint 3 (elbow)      : a=forearm,          alpha=0,     d=0
+        joint 4 (wrist pitch): a=0,                alpha=+pi/2, d=wrist_offset
+        joint 5 (wrist roll) : a=0,                alpha=0,     d=tool_length
+
+    Returned as a tuple of tuples for easy iteration.
+    """
+    return (
+        (0.0,             math.pi / 2, links["base_height"], 0.0),
+        (links["upper_arm"], 0.0,      0.0,                  0.0),
+        (links["forearm"],   0.0,      0.0,                  0.0),
+        (0.0,             math.pi / 2, links["wrist_offset"], 0.0),
+        (0.0,             0.0,         links["tool_length"], 0.0),
+    )
+
+
+# Backwards-compatible alias.  Issue #4 asks for a "DH parameter table"
+# config; we expose both names so callers can pick whichever they prefer.
+DEFAULT_DH_PARAMS = dh_table()
+
+
+# Joint indices.
+_BASE, _SHOULDER, _ELBOW, _WRIST, _WRIST_ROT = 0, 1, 2, 3, 4
+
+# The kinematic chain has five revolute joints; the Buddy arm's sixth servo
+# is the gripper and is ignored here.
+NUM_JOINTS = 5
+
+# Tolerances
+_POS_EPS = 1e-6     # mm; below this we treat the target as on-axis
+_REACH_EPS = 1e-3   # mm; numerical slack on reach checks
+_LIMIT_EPS = 1e-6   # deg; slack on joint-limit comparisons
+
+
+class KinematicsError(Exception):
+    """Raised when a pose cannot be reached or a joint limit would be violated."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _deg(rad):
+    return rad * 180.0 / math.pi
+
+
+def _rad(deg):
+    return deg * math.pi / 180.0
+
+
+def _wrap_deg(angle):
+    """Wrap an angle into the (-180, 180] degree range."""
+    a = ((angle + 180.0) % 360.0) - 180.0
+    if a == -180.0:
+        return 180.0
+    return a
+
+
+def _normalise_into_limits(joint_cfg, angle_deg):
+    """Return an equivalent angle that lies inside ``joint_cfg`` limits.
+
+    Tries the raw angle and ±360° shifts.  If none fit, returns ``None``.
+    """
+    if joint_cfg is None:
+        return angle_deg
+    for a in (angle_deg, angle_deg + 360.0, angle_deg - 360.0):
+        if (joint_cfg.min_angle - _LIMIT_EPS
+                <= a <= joint_cfg.max_angle + _LIMIT_EPS):
+            return a
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Forward kinematics
+# ---------------------------------------------------------------------------
+
+def forward(joint_angles, links=DEFAULT_LINKS):
+    """Return the Cartesian pose of the tool tip.
+
+    Parameters
+    ----------
+    joint_angles : sequence of float
+        Five joint angles in **degrees**, in chain order
+        ``(base, shoulder, elbow, wrist, wrist_rot)``.
+
+        * ``base``      – rotation about the vertical world axis.
+          ``0`` deg points the arm along +x.
+        * ``shoulder``  – pitch up from horizontal.  ``0`` deg = arm
+          extending horizontally; ``+90`` deg = arm pointing straight up.
+        * ``elbow``     – pitch relative to the upper arm.  ``0`` deg =
+          forearm continues in the same direction as the upper arm.
+        * ``wrist``     – pitch relative to the forearm.  ``0`` deg = the
+          tool axis continues in the same direction.
+        * ``wrist_rot`` – roll about the tool approach axis.
+
+    links : dict, optional
+        Link length dictionary (see :data:`DEFAULT_LINKS`).
+
+    Returns
+    -------
+    (x, y, z, tool_pitch_deg, tool_roll_deg)
+        Position of the tool tip in millimetres in the base frame.
+        ``tool_pitch_deg`` is the angle of the tool approach axis above
+        the horizontal plane (positive = pointing up), and
+        ``tool_roll_deg`` is the rotation of the gripper about that axis.
+    """
+    if len(joint_angles) != NUM_JOINTS:
+        raise KinematicsError(
+            "expected {} joint angles, got {}".format(NUM_JOINTS, len(joint_angles))
+        )
+
+    base, shoulder, elbow, wrist, wrist_rot = joint_angles
+    base_r = _rad(base)
+    shoulder_r = _rad(shoulder)
+    elbow_r = _rad(elbow)
+    wrist_r_rad = _rad(wrist)
+
+    a2 = links["upper_arm"]
+    a3 = links["forearm"]
+    d5 = links["tool_length"]
+    h0 = links["base_height"]
+    # wrist_offset shifts the wrist roll axis along the forearm; for the
+    # default zero value this collapses to the simple geometry below.
+    d4 = links["wrist_offset"]
+
+    # Cumulative pitch in the vertical plane.
+    p2 = shoulder_r
+    p3 = shoulder_r + elbow_r
+    p4 = shoulder_r + elbow_r + wrist_r_rad
+
+    # Position of each joint in the (r, z) plane that rotates with the base.
+    r_elbow = a2 * math.cos(p2)
+    z_elbow = h0 + a2 * math.sin(p2)
+    r_wrist = r_elbow + a3 * math.cos(p3)
+    z_wrist = z_elbow + a3 * math.sin(p3)
+    # The wrist_offset (d4) advances the wrist roll axis along the *tool*
+    # approach axis.  For d4=0 this term vanishes.
+    r_roll = r_wrist + d4 * math.cos(p4)
+    z_roll = z_wrist + d4 * math.sin(p4)
+    r_tip = r_roll + d5 * math.cos(p4)
+    z_tip = z_roll + d5 * math.sin(p4)
+
+    x = r_tip * math.cos(base_r)
+    y = r_tip * math.sin(base_r)
+    z = z_tip
+
+    tool_pitch_deg = _wrap_deg(_deg(p4))
+    tool_roll_deg = _wrap_deg(wrist_rot)
+    return (x, y, z, tool_pitch_deg, tool_roll_deg)
+
+
+# ---------------------------------------------------------------------------
+# Inverse kinematics
+# ---------------------------------------------------------------------------
+
+def inverse(target_pose,
+            links=DEFAULT_LINKS,
+            joint_configs=None,
+            elbow_up=True):
+    """Solve for joint angles that achieve ``target_pose``.
+
+    Parameters
+    ----------
+    target_pose : (x, y, z, tool_pitch_deg, tool_roll_deg)
+        Desired tool-tip position in millimetres and orientation in degrees.
+        ``tool_pitch_deg`` is measured from the horizontal plane,
+        ``tool_roll_deg`` is the gripper roll about the tool approach axis.
+    links : dict, optional
+        Link length dictionary; defaults to :data:`DEFAULT_LINKS`.
+    joint_configs : sequence of :class:`~buddy.arm.JointConfig` or None
+        Per-joint soft limits.  If supplied, any solution that violates a
+        joint's ``min_angle`` / ``max_angle`` raises
+        :class:`KinematicsError`.  The sequence must contain at least
+        :data:`NUM_JOINTS` entries; extras (e.g. the gripper) are ignored.
+    elbow_up : bool, optional
+        Pick the elbow-up branch of the planar 2R solution.  When
+        ``False`` the elbow-down branch is returned.
+
+    Returns
+    -------
+    list of float
+        Five joint angles in degrees in chain order
+        ``(base, shoulder, elbow, wrist, wrist_rot)``.
+
+    Raises
+    ------
+    KinematicsError
+        If the pose is unreachable, the math goes singular, or a joint
+        limit would be violated.
+    """
+    if len(target_pose) != 5:
+        raise KinematicsError(
+            "expected 5-tuple pose (x, y, z, pitch, roll), got {}".format(
+                len(target_pose)
+            )
+        )
+    x, y, z, tool_pitch_deg, tool_roll_deg = target_pose
+
+    a2 = links["upper_arm"]
+    a3 = links["forearm"]
+    d5 = links["tool_length"]
+    h0 = links["base_height"]
+    d4 = links["wrist_offset"]
+
+    # ---- 1. Base rotation -------------------------------------------------
+    horiz_r = math.sqrt(x * x + y * y)
+    if horiz_r < _POS_EPS:
+        # Singular: target on the vertical axis means base yaw is undefined.
+        # Return a documented sentinel of base=0 so behaviour is predictable.
+        base_deg = 0.0
+    else:
+        base_deg = _deg(math.atan2(y, x))
+
+    tool_pitch_rad = _rad(tool_pitch_deg)
+    cos_p = math.cos(tool_pitch_rad)
+    sin_p = math.sin(tool_pitch_rad)
+
+    # ---- 2. Wrist position (subtract tool-length contribution) -----------
+    # The wrist pitch axis sits one (tool_length + wrist_offset) back along
+    # the approach axis from the tool tip, in the (r, z) plane.
+    back = d5 + d4
+    wrist_r_pos = horiz_r - back * cos_p
+    wrist_z_pos = z - h0 - back * sin_p
+
+    # ---- 3. Planar 2R for shoulder + elbow -------------------------------
+    dist_sq = wrist_r_pos * wrist_r_pos + wrist_z_pos * wrist_z_pos
+    dist = math.sqrt(dist_sq)
+    max_reach = a2 + a3
+    min_reach = abs(a2 - a3)
+    if dist > max_reach + _REACH_EPS:
+        raise KinematicsError(
+            "target too far: distance {:.3f} > max reach {:.3f}".format(
+                dist, max_reach
+            )
+        )
+    if dist < min_reach - _REACH_EPS:
+        raise KinematicsError(
+            "target too close: distance {:.3f} < min reach {:.3f}".format(
+                dist, min_reach
+            )
+        )
+
+    # Law of cosines for the elbow interior angle.
+    cos_elbow = (dist_sq - a2 * a2 - a3 * a3) / (2.0 * a2 * a3)
+    # Numerical guard.
+    if cos_elbow > 1.0:
+        cos_elbow = 1.0
+    elif cos_elbow < -1.0:
+        cos_elbow = -1.0
+    elbow_rad = math.acos(cos_elbow)
+    if not elbow_up:
+        elbow_rad = -elbow_rad
+
+    # Shoulder angle = polar angle to wrist in (r, z) - inner triangle angle.
+    phi = math.atan2(wrist_z_pos, wrist_r_pos)
+    psi = math.atan2(a3 * math.sin(elbow_rad), a2 + a3 * math.cos(elbow_rad))
+    shoulder_rad = phi - psi
+
+    shoulder_deg = _deg(shoulder_rad)
+    elbow_deg = _deg(elbow_rad)
+
+    # ---- 4. Wrist pitch from desired tool pitch --------------------------
+    wrist_deg = tool_pitch_deg - shoulder_deg - elbow_deg
+
+    # ---- 5. Wrist roll passes through ------------------------------------
+    wrist_rot_deg = tool_roll_deg
+
+    angles = [
+        _wrap_deg(base_deg),
+        _wrap_deg(shoulder_deg),
+        _wrap_deg(elbow_deg),
+        _wrap_deg(wrist_deg),
+        _wrap_deg(wrist_rot_deg),
+    ]
+
+    # ---- 6. Joint-limit enforcement --------------------------------------
+    if joint_configs is not None:
+        if len(joint_configs) < NUM_JOINTS:
+            raise KinematicsError(
+                "joint_configs must contain at least {} entries".format(NUM_JOINTS)
+            )
+        for i in range(NUM_JOINTS):
+            cfg = joint_configs[i]
+            normalised = _normalise_into_limits(cfg, angles[i])
+            if normalised is None:
+                raise KinematicsError(
+                    "joint {} angle {:.2f} deg out of limits "
+                    "[{}, {}]".format(
+                        i, angles[i], cfg.min_angle, cfg.max_angle
+                    )
+                )
+            angles[i] = normalised
+
+    return angles
+
+
+__all__ = [
+    "DEFAULT_LINKS",
+    "DEFAULT_DH_PARAMS",
+    "NUM_JOINTS",
+    "KinematicsError",
+    "dh_table",
+    "forward",
+    "inverse",
+]

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -1,0 +1,338 @@
+"""Tests for :mod:`buddy.kinematics`.
+
+These tests are pure math — no fake servos required.  They cover:
+
+* Forward kinematics at known poses (all-zeros, vertical, base-rotated).
+* Forward → inverse round-trip across a battery of reachable targets.
+* Singularity handling (target on the vertical base axis).
+* Out-of-reach poses raising :class:`KinematicsError`.
+* Joint-limit enforcement against a real :class:`buddy.arm.JointConfig`.
+* Elbow-up vs. elbow-down branch selection.
+* The DH parameter table is exposed as a tuple of 5 rows.
+"""
+import math
+
+import pytest
+
+from buddy.arm import JointConfig
+from buddy.kinematics import (
+    DEFAULT_DH_PARAMS,
+    DEFAULT_LINKS,
+    KinematicsError,
+    NUM_JOINTS,
+    dh_table,
+    forward,
+    inverse,
+)
+
+
+# ---- helpers ---------------------------------------------------------------
+
+def _pose_close(a, b, pos_tol=1e-3, ang_tol=1e-3):
+    return (
+        abs(a[0] - b[0]) < pos_tol
+        and abs(a[1] - b[1]) < pos_tol
+        and abs(a[2] - b[2]) < pos_tol
+        and abs(a[3] - b[3]) < ang_tol
+        and abs(a[4] - b[4]) < ang_tol
+    )
+
+
+def _angles_close(a, b, tol=1e-3):
+    if len(a) != len(b):
+        return False
+    for x, y in zip(a, b):
+        # Account for ±360 equivalence.
+        diff = ((x - y + 540) % 360) - 180
+        if abs(diff) > tol:
+            return False
+    return True
+
+
+# ---- DH table ---------------------------------------------------------------
+
+def test_dh_table_has_five_rows():
+    table = dh_table()
+    assert len(table) == NUM_JOINTS
+    for row in table:
+        assert len(row) == 4  # (a, alpha, d, theta_offset)
+
+
+def test_default_dh_params_alias_matches_dh_table():
+    assert DEFAULT_DH_PARAMS == dh_table()
+
+
+def test_dh_table_uses_supplied_links():
+    custom = dict(DEFAULT_LINKS)
+    custom["upper_arm"] = 250.0
+    table = dh_table(custom)
+    # joint 2 (index 1) row's a-parameter is upper_arm
+    assert table[1][0] == 250.0
+
+
+# ---- Forward kinematics: known reference poses -----------------------------
+
+def test_forward_all_zeros_extends_along_x():
+    pose = forward([0.0, 0.0, 0.0, 0.0, 0.0])
+    expected_x = (
+        DEFAULT_LINKS["upper_arm"]
+        + DEFAULT_LINKS["forearm"]
+        + DEFAULT_LINKS["wrist_offset"]
+        + DEFAULT_LINKS["tool_length"]
+    )
+    assert abs(pose[0] - expected_x) < 1e-6
+    assert abs(pose[1]) < 1e-6
+    assert abs(pose[2] - DEFAULT_LINKS["base_height"]) < 1e-6
+    assert abs(pose[3]) < 1e-6  # tool pitch
+    assert abs(pose[4]) < 1e-6  # tool roll
+
+
+def test_forward_shoulder_90_points_up():
+    pose = forward([0.0, 90.0, 0.0, 0.0, 0.0])
+    expected_z = (
+        DEFAULT_LINKS["base_height"]
+        + DEFAULT_LINKS["upper_arm"]
+        + DEFAULT_LINKS["forearm"]
+        + DEFAULT_LINKS["wrist_offset"]
+        + DEFAULT_LINKS["tool_length"]
+    )
+    assert abs(pose[0]) < 1e-6
+    assert abs(pose[1]) < 1e-6
+    assert abs(pose[2] - expected_z) < 1e-6
+    assert abs(pose[3] - 90.0) < 1e-6
+
+
+def test_forward_base_rotation_swings_to_y_axis():
+    pose = forward([90.0, 0.0, 0.0, 0.0, 0.0])
+    # x=0 (within float tolerance), y=full reach
+    expected_r = (
+        DEFAULT_LINKS["upper_arm"]
+        + DEFAULT_LINKS["forearm"]
+        + DEFAULT_LINKS["wrist_offset"]
+        + DEFAULT_LINKS["tool_length"]
+    )
+    assert abs(pose[0]) < 1e-6
+    assert abs(pose[1] - expected_r) < 1e-6
+
+
+def test_forward_returns_wrist_roll_unchanged():
+    pose = forward([0.0, 0.0, 0.0, 0.0, 45.0])
+    assert abs(pose[4] - 45.0) < 1e-6
+
+
+def test_forward_rejects_wrong_arity():
+    with pytest.raises(KinematicsError, match="expected 5"):
+        forward([0.0, 0.0, 0.0, 0.0])  # only 4 angles
+
+
+# ---- Forward → inverse round-trip ------------------------------------------
+
+@pytest.mark.parametrize("target", [
+    (200.0,    0.0, 100.0,   0.0,   0.0),
+    (150.0,  100.0, 200.0,  30.0,   0.0),
+    (100.0, -100.0, 250.0, -45.0,  90.0),
+    (200.0,   50.0, 150.0,   0.0,  30.0),
+    (250.0,    0.0, 150.0,  10.0, -45.0),
+    (-150.0, 100.0, 200.0, -10.0,   0.0),
+    (-200.0,   0.0, 100.0,   0.0,   0.0),  # behind the base
+    (50.0,   200.0, 200.0,  20.0,  60.0),
+])
+def test_forward_inverse_round_trip(target):
+    angles = inverse(target)
+    back = forward(angles)
+    assert _pose_close(target, back, pos_tol=1e-3, ang_tol=1e-3)
+
+
+def test_inverse_then_forward_returns_consistent_joints():
+    """Two solutions of inverse for the same target should yield the same FK."""
+    target = (180.0, 90.0, 180.0, 15.0, 0.0)
+    up = inverse(target, elbow_up=True)
+    down = inverse(target, elbow_up=False)
+    assert not _angles_close(up, down)  # different solutions
+    assert _pose_close(forward(up), forward(down))
+
+
+# ---- Singularity / sentinel handling ---------------------------------------
+
+def test_inverse_on_vertical_axis_returns_base_zero_sentinel():
+    # x = y = 0, target straight up.  The base yaw is undefined; the
+    # documented sentinel is base = 0.
+    target = (0.0, 0.0, 400.0, 90.0, 0.0)
+    angles = inverse(target)
+    assert angles[0] == 0.0  # exact sentinel value
+    # FK should still recover the requested pose modulo the base sentinel.
+    back = forward(angles)
+    assert abs(back[0]) < 1e-6
+    assert abs(back[1]) < 1e-6
+    assert abs(back[2] - 400.0) < 1e-6
+
+
+# ---- Out-of-reach handling -------------------------------------------------
+
+def test_inverse_too_far_raises():
+    # 10 metres is well past the 300 mm + small wrist offset reach.
+    with pytest.raises(KinematicsError, match="too far"):
+        inverse((10000.0, 0.0, 100.0, 0.0, 0.0))
+
+
+def test_inverse_too_close_raises_when_links_unequal():
+    # Make the links unequal so there is a non-zero minimum reach.
+    links = dict(DEFAULT_LINKS)
+    links["upper_arm"] = 200.0
+    links["forearm"] = 50.0
+    # Place the wrist at the shoulder origin (after subtracting tool length).
+    target = (
+        links["tool_length"] + links["wrist_offset"],
+        0.0,
+        links["base_height"],
+        0.0,
+        0.0,
+    )
+    with pytest.raises(KinematicsError, match="too close"):
+        inverse(target, links=links)
+
+
+def test_inverse_rejects_wrong_arity_pose():
+    with pytest.raises(KinematicsError, match="expected 5"):
+        inverse((100.0, 0.0, 100.0, 0.0))  # only 4 elements
+
+
+# ---- Joint-limit enforcement -----------------------------------------------
+
+def _full_range_configs():
+    """Five joints all unconstrained (-180..180)."""
+    return [JointConfig(servo_id=i + 1, min_angle=-180.0, max_angle=180.0,
+                        home=0.0)
+            for i in range(NUM_JOINTS)]
+
+
+def test_inverse_passes_with_full_range_limits():
+    cfgs = _full_range_configs()
+    target = (200.0, 0.0, 150.0, 10.0, 0.0)
+    # Should not raise.
+    angles = inverse(target, joint_configs=cfgs)
+    assert len(angles) == NUM_JOINTS
+
+
+def test_inverse_violates_joint_limit_raises():
+    # Force a tight limit on the shoulder so the obvious solution is
+    # outside the window.
+    cfgs = _full_range_configs()
+    cfgs[1] = JointConfig(servo_id=2, min_angle=80.0, max_angle=100.0,
+                          home=90.0)
+    # A target straight ahead makes the shoulder ~ -54 deg, which is
+    # well outside [80, 100].
+    target = (200.0, 0.0, 100.0, 0.0, 0.0)
+    with pytest.raises(KinematicsError, match="out of limits"):
+        inverse(target, joint_configs=cfgs)
+
+
+def test_inverse_joint_configs_too_short_raises():
+    cfgs = _full_range_configs()[:2]  # only two configs supplied
+    target = (200.0, 0.0, 100.0, 0.0, 0.0)
+    with pytest.raises(KinematicsError, match="at least"):
+        inverse(target, joint_configs=cfgs)
+
+
+def test_inverse_normalises_into_360_window():
+    """A solution of -45 deg should map into a [0, 360]-style joint window."""
+    # Build configs whose windows are 0..360 (as the default arm uses).
+    cfgs = [JointConfig(servo_id=i + 1, min_angle=0.0, max_angle=360.0,
+                        home=180.0)
+            for i in range(NUM_JOINTS)]
+    # Target that yields a negative base angle (-90 deg).
+    target = (0.0, -200.0, 100.0, 0.0, 0.0)
+    angles = inverse(target, joint_configs=cfgs)
+    # The base angle should have been shifted by +360 to land in 0..360.
+    assert 0.0 <= angles[0] <= 360.0
+    # The other angles must still be inside the window or have been
+    # normalised; sanity-check by re-computing FK.
+    # FK takes the same angle modulo 360 for the base; pose should match.
+    back = forward(angles)
+    assert abs(back[0]) < 1e-3
+    assert abs(back[1] - (-200.0)) < 1e-3
+
+
+def test_inverse_accepts_none_joint_configs():
+    # Explicit None should behave the same as omitting the argument.
+    angles_default = inverse((200.0, 0.0, 100.0, 0.0, 0.0))
+    angles_none = inverse((200.0, 0.0, 100.0, 0.0, 0.0), joint_configs=None)
+    assert _angles_close(angles_default, angles_none)
+
+
+def test_inverse_per_joint_none_skips_limit_check():
+    """Within the joint_configs sequence, individual ``None`` entries should
+    skip the per-joint limit check for that joint only."""
+    cfgs = _full_range_configs()
+    cfgs[0] = None  # base unconstrained
+    target = (200.0, 0.0, 100.0, 0.0, 0.0)
+    angles = inverse(target, joint_configs=cfgs)
+    assert len(angles) == NUM_JOINTS
+
+
+def test_inverse_at_max_reach_succeeds():
+    """A target exactly at the maximum reach exercises the cos_elbow=+1
+    numerical guard and must still return a valid arm-extended solution."""
+    full_reach = (
+        DEFAULT_LINKS["upper_arm"]
+        + DEFAULT_LINKS["forearm"]
+    )
+    # Place the wrist exactly at full extension; the tool extends in the
+    # same direction so the tip lands at full_reach + back along +x.
+    back = DEFAULT_LINKS["tool_length"] + DEFAULT_LINKS["wrist_offset"]
+    target = (full_reach + back, 0.0, DEFAULT_LINKS["base_height"], 0.0, 0.0)
+    angles = inverse(target)
+    # Elbow should be ~0 (arm fully extended).
+    assert abs(angles[2]) < 1e-3
+
+
+def test_inverse_at_min_reach_succeeds():
+    """A target exactly at the minimum reach (folded arm) must succeed and
+    exercises the cos_elbow=-1 numerical guard."""
+    links = dict(DEFAULT_LINKS)
+    links["upper_arm"] = 200.0
+    links["forearm"] = 50.0
+    # Wrist on top of the shoulder -> distance = 0, but min_reach is
+    # |200-50| = 150, so we want distance == 150 (fully folded).
+    back = links["tool_length"] + links["wrist_offset"]
+    # Place tool tip horizontally so the wrist is 150 mm from the
+    # shoulder along the same axis (tool offset added back in).
+    target = (links["upper_arm"] - links["forearm"] + back,
+              0.0,
+              links["base_height"],
+              0.0, 0.0)
+    angles = inverse(target, links=links)
+    # Elbow should be ~180 deg (fully folded).
+    assert abs(abs(angles[2]) - 180.0) < 1e-3
+
+
+# ---- Elbow-up / elbow-down branches ----------------------------------------
+
+def test_elbow_up_and_down_yield_same_tip_position():
+    target = (200.0, 0.0, 150.0, 0.0, 0.0)
+    up = inverse(target, elbow_up=True)
+    down = inverse(target, elbow_up=False)
+    pose_up = forward(up)
+    pose_down = forward(down)
+    # Position should be identical; orientation likewise (we constrain it).
+    assert abs(pose_up[0] - pose_down[0]) < 1e-3
+    assert abs(pose_up[1] - pose_down[1]) < 1e-3
+    assert abs(pose_up[2] - pose_down[2]) < 1e-3
+    # And the elbow joint values themselves should differ in sign.
+    assert math.copysign(1.0, up[2]) != math.copysign(1.0, down[2])
+
+
+# ---- Custom link parameters -------------------------------------------------
+
+def test_custom_links_round_trip():
+    custom = {
+        "base_height":  150.0,
+        "upper_arm":    180.0,
+        "forearm":      150.0,
+        "wrist_offset":  10.0,
+        "tool_length":   75.0,
+    }
+    target = (300.0, 50.0, 200.0, 5.0, 0.0)
+    angles = inverse(target, links=custom)
+    back = forward(angles, links=custom)
+    assert _pose_close(target, back, pos_tol=1e-3, ang_tol=1e-3)


### PR DESCRIPTION
Closes #4.

Built on top of #2 (PR #10). The base branch is `issue-2-arm-abstraction`; once #2 merges, GitHub will auto-update this PR's base to `main`.

## Summary

Adds `buddy/kinematics.py` with closed-form forward and inverse kinematics for the 5-DoF positioning chain (`base`, `shoulder`, `elbow`, `wrist`, `wrist_rot`). The 6th servo (gripper) is intentionally outside the kinematic model — it's an end-effector tool, not a positioning DoF.

### FK / IK approach

**Analytical, not numeric.** The arm topology decomposes cleanly:

1. Base yaw recovered directly from `atan2(y, x)`.
2. Shoulder/elbow form a planar 2-link manipulator solved with the law of cosines (elbow-up / elbow-down branches selectable).
3. Wrist pitch derived from the desired tool pitch and the cumulative shoulder + elbow pitch.
4. Wrist roll passes straight through.

Analytical was preferred because:

- It is **dramatically faster** on MicroPython than a Jacobian / damped-least-squares loop (no per-iteration matrix multiplies).
- It has **no convergence-failure modes** — there's a closed-form answer or a clear "out of reach" error.
- The 5-DoF chain has no spherical wrist, but it doesn't need one for positioning + tool pitch + roll, which is what the IK exposes via a `(x, y, z, tool_pitch_deg, tool_roll_deg)` 5-tuple. A 5-DoF arm cannot independently set all three orientation components, and the API reflects that honestly.

### DH parameter table

The config lives in `DEFAULT_LINKS` (link lengths in mm) with a `dh_table()` helper that emits the equivalent classical Denavit-Hartenberg rows for downstream tooling. Both `DEFAULT_LINKS` and `DEFAULT_DH_PARAMS` are exposed at the package level.

### Joint-limit handling

`inverse(..., joint_configs=cfgs)` enforces each joint's `min_angle` / `max_angle` window from the existing `buddy.arm.JointConfig`. The check tries +/- 360 shifts of the raw solution so a -45 deg base angle can match a `[0, 360]` servo window. Out-of-limit angles raise `KinematicsError` with a diagnostic message.

### Singularity / out-of-reach handling

- Vertical-axis target (`x = y = 0`) returns `base = 0` as a documented sentinel rather than spinning unpredictably.
- Targets beyond `upper_arm + forearm` raise `KinematicsError("target too far ...")`.
- Targets inside the minimum reach (when links are unequal) raise `KinematicsError("target too close ...")`.
- Cosine-law results are numerically clamped to `[-1, +1]` to absorb float overshoot at full extension / full fold.

## Open hardware-measurement questions

The default link lengths in `DEFAULT_LINKS` are placeholders chosen to make the math exercise sensibly:

- `base_height = 100 mm`
- `upper_arm = 120 mm`
- `forearm = 120 mm`
- `wrist_offset = 0 mm`
- `tool_length = 60 mm`

Before relying on Cartesian motion on real hardware, a follow-up should measure:

1. Vertical distance from the base mounting plate to the shoulder pitch axis.
2. Centre-to-centre distance from the shoulder pitch axis to the elbow pitch axis.
3. Centre-to-centre distance from the elbow pitch axis to the wrist pitch axis.
4. Any axial offset between the wrist pitch and wrist roll axes (often 0 for clean designs but non-zero on some bracket stacks).
5. Distance from the wrist roll axis to the gripper finger contact point with the gripper closed.

A `README.md` covering measurement procedure is the natural follow-up issue. (The repo currently has no top-level README.)

## Test plan

- [x] `pytest tests/test_kinematics.py` — 31 tests, all pass.
- [x] `pytest --cov=buddy.kinematics` reports 98% coverage on `buddy/kinematics.py` (only the defensive `cos_elbow` numerical-overshoot guards are unhit, well above the 80% bar).
- [x] Full suite `pytest --cov` reports 97 tests passing, 99% overall coverage. No regressions.
- [ ] On-hardware verification once real link lengths are measured.

## Test coverage details

```
buddy/kinematics.py     111      2    98%
```