### PR TITLE
Phase 5: Web backend (HTTP + WebSocket)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ __pycache__/
 .coverage
 htmlcov/
 .DS_Store
+
+# Wi-Fi and other secrets — NEVER commit real credentials.
+wifi_credentials.json
+*.secret
+*.secrets.json
+secrets.py

--- a/buddy/web/__init__.py
+++ b/buddy/web/__init__.py
@@ -1,0 +1,19 @@
+"""Web backend for the Buddy arm.
+
+Sub-modules
+-----------
+- :mod:`buddy.web.server`  : HTTP + WebSocket API around an :class:`Arm`
+- :mod:`buddy.web.wifi`    : STA + AP-fallback Wi-Fi bring-up helpers
+"""
+
+from .server import create_app, ArmService, state_payload
+from .wifi import connect, load_credentials, WiFiError
+
+__all__ = [
+    "create_app",
+    "ArmService",
+    "state_payload",
+    "connect",
+    "load_credentials",
+    "WiFiError",
+]

--- a/buddy/web/server.py
+++ b/buddy/web/server.py
@@ -1,0 +1,353 @@
+"""HTTP + WebSocket backend for the Buddy arm.
+
+Framework decision
+------------------
+We use **microdot** (https://github.com/miguelgrinberg/microdot) rather than
+hand-rolled sockets:
+
+* Microdot ships a MicroPython-compatible build (``microdot`` on PyPI installs
+  cleanly under both CPython and MicroPython — same API on both).
+* It gives us routing, request parsing, JSON helpers, the ``test_client``
+  harness and a tiny WebSocket implementation in ~20 KB.
+* Hand-rolling the same surface area on top of ``socket``/``select`` would be
+  several hundred lines of code (HTTP request line + headers parser, chunked
+  encoding for SSE/WS, etc.) for no functional gain — and it would make this
+  module much harder to unit-test from CPython.
+
+The cost is one extra file on the device (``microdot.py`` from
+:command:`mip install microdot`) and ~40 KB of RAM at runtime, which is well
+inside the budget on a Pico W / ESP32.
+
+Endpoint summary
+----------------
+====================  ===========================================================
+``GET  /state``       JSON snapshot: per-joint angles, gripper, torque,
+                      temperature.
+``POST /move``        Body either ``{"angles": {...}|[...]}`` (joint-space) or
+                      ``{"pose": {...}}`` (Cartesian — delegated to a
+                      caller-supplied IK callable; Phase 4 plugs in here).
+``POST /torque``      Body ``{"enabled": bool, "joint": "all"|name|index}``.
+``POST /gripper``     Body ``{"action": "open"|"close"}``.
+``POST /home``        No body. Drives the arm to its configured home pose.
+``GET  /ws``          WebSocket stream — joint state JSON at ``stream_hz`` Hz
+                      (default 20 Hz) for the 3D viewer.
+====================  ===========================================================
+
+Cartesian / IK integration point
+--------------------------------
+:func:`create_app` accepts a ``pose_to_joints`` callable.  When the
+``/move`` endpoint receives ``{"pose": {...}}``, it forwards the pose dict
+to that callable and expects either a list of joint angles in arm order or a
+``{joint_name: angle}`` mapping.  Phase 4's IK module is expected to plug in
+here without any further changes to the server.
+"""
+
+try:
+    from microdot import Microdot
+    from microdot.websocket import with_websocket
+except ImportError:  # pragma: no cover - smoke import diagnostic
+    raise ImportError(
+        "microdot is required for buddy.web.server. "
+        "On MicroPython: `mip install microdot`. "
+        "On CPython: `pip install microdot`."
+    )
+
+try:
+    import ujson as json   # MicroPython
+except ImportError:        # pragma: no cover - CPython
+    import json
+
+try:
+    import utime as time   # MicroPython
+except ImportError:        # pragma: no cover - CPython
+    import time
+
+
+# Default streaming rate for /ws.  20 Hz keeps the 3D viewer smooth without
+# saturating the half-duplex servo bus with read traffic.
+DEFAULT_STREAM_HZ = 20
+
+
+def _sleep_ms(ms):
+    """Cross-runtime millisecond sleep (works on both CPython and MicroPython)."""
+    if hasattr(time, "sleep_ms"):
+        time.sleep_ms(int(ms))
+    else:  # pragma: no cover - CPython only
+        time.sleep(ms / 1000.0)
+
+
+def _safe_call(fn, *args, **kwargs):
+    """Invoke ``fn(*args, **kwargs)`` returning ``(value, error_str_or_None)``.
+
+    Used by the request handlers so a single misbehaving servo (timeout, bad
+    checksum, etc.) returns a structured 500 instead of a stack trace.
+    """
+    try:
+        return fn(*args, **kwargs), None
+    except Exception as exc:
+        return None, "{}: {}".format(type(exc).__name__, exc)
+
+
+class ArmService:
+    """Façade around an :class:`Arm` that the route handlers call into.
+
+    Centralising the arm operations here gives us:
+
+    * one place to translate :class:`buddy.arm.Arm` calls into JSON-friendly
+      dicts (so the route handlers stay tiny and easy to read),
+    * a stable seam for tests — ``ArmService`` can be subclassed or its
+      ``arm`` attribute swapped for a mock,
+    * graceful degradation when optional sensor reads (temperature, load) are
+      not implemented or raise on a particular joint.
+    """
+
+    def __init__(self, arm, pose_to_joints=None):
+        self.arm = arm
+        # Optional Cartesian-IK callable.  Phase 4 plugs in here.
+        # Signature: pose_to_joints(pose_dict) -> list[float] | {name: float}
+        self.pose_to_joints = pose_to_joints
+
+    # ---- read path ------------------------------------------------------
+
+    def state(self):
+        """Return a JSON-serialisable dict describing the whole arm."""
+        arm = self.arm
+        names = arm.joint_names
+        angles, err = _safe_call(arm.read_all)
+        joints = []
+        for i, name in enumerate(names):
+            joint_cfg = arm.joint(i)
+            entry = {
+                "name": name,
+                "servo_id": joint_cfg.servo_id,
+                "min_angle": joint_cfg.min_angle,
+                "max_angle": joint_cfg.max_angle,
+                "is_gripper": bool(joint_cfg.is_gripper),
+                "angle": angles[i] if (angles is not None and i < len(angles)) else None,
+            }
+            # Optional reads — guarded individually so one slow/failing
+            # register doesn't blank the whole snapshot.
+            temp, _ = _safe_call(self._read_temp, joint_cfg.servo_id)
+            entry["temperature"] = temp
+            entry["torque"] = self._read_torque(joint_cfg.servo_id)
+            joints.append(entry)
+        return {
+            "joints": joints,
+            "gripper": self._gripper_summary(joints),
+            "error": err,
+        }
+
+    def _read_temp(self, servo_id):
+        # Some Arm implementations don't expose temperature via the driver;
+        # fall back to None silently.
+        driver = getattr(self.arm, "_driver", None)
+        if driver is None or not hasattr(driver, "read_temperature"):
+            return None
+        return driver.read_temperature(servo_id)
+
+    def _read_torque(self, servo_id):
+        # Arm doesn't currently cache the torque-enable state and the register
+        # isn't part of the standard read path; we expose ``None`` so the UI
+        # can render "unknown" rather than guessing.
+        return None
+
+    @staticmethod
+    def _gripper_summary(joints):
+        for j in joints:
+            if j.get("is_gripper"):
+                return {"name": j["name"], "angle": j["angle"]}
+        return None
+
+    # ---- write path -----------------------------------------------------
+
+    def move_joints(self, angles, speed=None, accel=None):
+        return _safe_call(self.arm.move_all, angles, speed=speed, accel=accel)
+
+    def move_pose(self, pose, speed=None, accel=None):
+        if self.pose_to_joints is None:
+            return None, "no IK adapter configured (Phase 4 not yet wired in)"
+        try:
+            joints = self.pose_to_joints(pose)
+        except Exception as exc:
+            return None, "IK error: {}: {}".format(type(exc).__name__, exc)
+        return _safe_call(self.arm.move_all, joints, speed=speed, accel=accel)
+
+    def set_torque(self, enabled, key="all"):
+        if enabled:
+            return _safe_call(self.arm.enable_torque, key)
+        return _safe_call(self.arm.disable_torque, key)
+
+    def gripper(self, action):
+        if action == "open":
+            return _safe_call(self.arm.gripper_open)
+        if action == "close":
+            return _safe_call(self.arm.gripper_close)
+        return None, "unknown gripper action: {!r}".format(action)
+
+    def home(self, speed=None, accel=None):
+        return _safe_call(self.arm.home, speed=speed, accel=accel)
+
+
+def state_payload(service):
+    """Produce a stable JSON-string representation of the arm state.
+
+    Used by both :func:`create_app`'s ``/state`` handler and the ``/ws``
+    stream loop, so they always emit identical schema.  Exposed at module
+    level so tests can pin the payload shape without spinning up an HTTP
+    client.
+    """
+    return service.state()
+
+
+def _parse_joint_key(value):
+    """Allow ``"all"`` / null / int / string for joint targeting."""
+    if value is None or value == "all":
+        return "all"
+    if isinstance(value, bool):
+        # bools are also ints in Python — explicitly reject to avoid surprises.
+        raise ValueError("joint key cannot be a bool")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return value
+    raise ValueError("invalid joint key: {!r}".format(value))
+
+
+def _request_json(req):
+    """Best-effort JSON body parser that tolerates empty / non-JSON bodies."""
+    body = req.json
+    if body is None:
+        return {}
+    if not isinstance(body, dict):
+        raise ValueError("expected JSON object")
+    return body
+
+
+def create_app(arm, pose_to_joints=None, stream_hz=DEFAULT_STREAM_HZ):
+    """Build and return a configured :class:`microdot.Microdot` app.
+
+    Parameters
+    ----------
+    arm : buddy.arm.Arm
+        The arm to control.  May be a real :class:`Arm` or any duck-typed
+        replacement (tests pass a mock).
+    pose_to_joints : callable, optional
+        ``pose_dict -> list[float]|dict`` IK adapter for ``/move`` Cartesian
+        requests.  Defaults to ``None`` (Cartesian moves return 501).
+    stream_hz : int
+        WebSocket ``/ws`` broadcast rate.
+
+    Returns
+    -------
+    (app, service) : tuple
+        ``app`` is the microdot instance (call ``.run(host, port)``);
+        ``service`` is the :class:`ArmService` so callers / tests can poke
+        into the arm without going through HTTP.
+    """
+    app = Microdot()
+    service = ArmService(arm, pose_to_joints=pose_to_joints)
+    # Stash on the app so tests can introspect.
+    app.service = service
+    app.stream_hz = stream_hz
+
+    @app.get("/state")
+    def get_state(req):
+        return state_payload(service)
+
+    @app.post("/move")
+    def post_move(req):
+        try:
+            body = _request_json(req)
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}, 400
+
+        speed = body.get("speed")
+        accel = body.get("accel")
+
+        if "angles" in body:
+            angles = body["angles"]
+            if not isinstance(angles, (list, dict)):
+                return {"ok": False, "error": "'angles' must be list or object"}, 400
+            _, err = service.move_joints(angles, speed=speed, accel=accel)
+            if err is not None:
+                return {"ok": False, "error": err}, 500
+            return {"ok": True, "mode": "joint"}
+
+        if "pose" in body:
+            pose = body["pose"]
+            if not isinstance(pose, dict):
+                return {"ok": False, "error": "'pose' must be an object"}, 400
+            _, err = service.move_pose(pose, speed=speed, accel=accel)
+            if err is not None:
+                # 501 = "Not Implemented" when no IK is wired in;
+                # 500 for genuine runtime failures.
+                status = 501 if "no IK adapter" in err else 500
+                return {"ok": False, "error": err}, status
+            return {"ok": True, "mode": "pose"}
+
+        return {"ok": False, "error": "body must include 'angles' or 'pose'"}, 400
+
+    @app.post("/torque")
+    def post_torque(req):
+        try:
+            body = _request_json(req)
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}, 400
+        if "enabled" not in body:
+            return {"ok": False, "error": "'enabled' (bool) required"}, 400
+        try:
+            key = _parse_joint_key(body.get("joint", "all"))
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}, 400
+        _, err = service.set_torque(bool(body["enabled"]), key=key)
+        if err is not None:
+            return {"ok": False, "error": err}, 500
+        return {"ok": True, "enabled": bool(body["enabled"]), "joint": key}
+
+    @app.post("/gripper")
+    def post_gripper(req):
+        try:
+            body = _request_json(req)
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}, 400
+        action = body.get("action")
+        if action not in ("open", "close"):
+            return {"ok": False, "error": "'action' must be 'open' or 'close'"}, 400
+        _, err = service.gripper(action)
+        if err is not None:
+            return {"ok": False, "error": err}, 500
+        return {"ok": True, "action": action}
+
+    @app.post("/home")
+    def post_home(req):
+        try:
+            body = _request_json(req)
+        except ValueError:
+            body = {}
+        _, err = service.home(speed=body.get("speed"), accel=body.get("accel"))
+        if err is not None:
+            return {"ok": False, "error": err}, 500
+        return {"ok": True}
+
+    @app.route("/ws")
+    @with_websocket
+    def ws_state(req, ws):  # pragma: no cover - exercised via WS test below
+        period_ms = max(1, int(1000 / app.stream_hz))
+        while True:
+            payload = state_payload(service)
+            ws.send(json.dumps(payload))
+            _sleep_ms(period_ms)
+
+    return app, service
+
+
+# -- top-level entry point used on-device --------------------------------------
+
+def run(arm, host="0.0.0.0", port=80, **kwargs):  # pragma: no cover - device entry point
+    """Convenience wrapper used by ``main.py`` on the microcontroller.
+
+    Builds the app, starts microdot's blocking event loop and keeps the
+    arm/service references alive.  Tests use :func:`create_app` directly.
+    """
+    app, _ = create_app(arm, **kwargs)
+    app.run(host=host, port=port)

--- a/buddy/web/wifi.py
+++ b/buddy/web/wifi.py
@@ -1,0 +1,199 @@
+"""Wi-Fi bring-up helper for the Buddy arm.
+
+Behaviour
+---------
+1. Read JSON credentials from a file on flash (default
+   ``wifi_credentials.json``).  The file is **not** committed to the repo —
+   ``wifi_credentials.example.json`` is the template.
+2. Try to join the configured SSID in *station* (STA) mode.
+3. If STA mode does not associate within ``timeout_s`` seconds, drop into
+   *access-point* (AP) mode using the ``ap_fallback`` block from the
+   credentials file (or sensible defaults).
+
+Credentials JSON schema
+-----------------------
+::
+
+    {
+      "ssid": "your-wifi-ssid",
+      "password": "your-wifi-password",
+      "hostname": "buddy",
+      "ap_fallback": {
+        "ssid": "buddy-arm",
+        "password": "buddy1234"
+      }
+    }
+
+Only ``ssid`` and ``password`` are required.  The ``ap_fallback`` block is
+optional; defaults are ``{"ssid": "buddy-arm", "password": "buddy1234"}``.
+
+Imports
+-------
+``network`` is MicroPython-only.  We import it lazily inside :func:`connect`
+so this module can be unit-tested under CPython by injecting a mock
+``network`` module via ``sys.modules['network']`` (see
+``tests/conftest.py`` for the pattern, mirroring how ``machine`` is mocked).
+"""
+
+try:
+    import ujson as json   # MicroPython
+except ImportError:        # pragma: no cover - CPython
+    import json
+
+try:
+    import utime as time   # MicroPython
+except ImportError:        # pragma: no cover - CPython
+    import time
+
+
+DEFAULT_CRED_PATH = "wifi_credentials.json"
+DEFAULT_AP_SSID = "buddy-arm"
+DEFAULT_AP_PASSWORD = "buddy1234"
+DEFAULT_TIMEOUT_S = 15
+# Poll every this many ms while waiting for STA association.
+_POLL_INTERVAL_MS = 500
+
+
+class WiFiError(Exception):
+    """Raised when both STA and AP bring-up fail."""
+
+
+def _sleep_ms(ms):
+    if hasattr(time, "sleep_ms"):
+        time.sleep_ms(int(ms))
+    else:  # pragma: no cover - CPython
+        time.sleep(ms / 1000.0)
+
+
+def load_credentials(path=DEFAULT_CRED_PATH):
+    """Load and validate the Wi-Fi credentials JSON file.
+
+    Returns the decoded dict.  Raises :class:`WiFiError` if the file is
+    missing or malformed.
+    """
+    try:
+        with open(path, "r") as f:
+            data = json.loads(f.read())
+    except OSError as exc:
+        raise WiFiError("credentials file not found at {!r}: {}".format(path, exc))
+    except ValueError as exc:
+        raise WiFiError("credentials file is not valid JSON: {}".format(exc))
+    if not isinstance(data, dict):
+        raise WiFiError("credentials file must contain a JSON object")
+    if "ssid" not in data or "password" not in data:
+        raise WiFiError("credentials file must include 'ssid' and 'password'")
+    return data
+
+
+def _import_network():
+    """Lazy import so tests can stub ``network`` via ``sys.modules``."""
+    import network  # noqa: WPS433 - intentional runtime import
+    return network
+
+
+def _start_sta(network_mod, ssid, password, hostname=None, timeout_s=DEFAULT_TIMEOUT_S):
+    """Try to connect in STA mode.  Returns the WLAN interface on success,
+    or ``None`` on timeout / association failure."""
+    sta = network_mod.WLAN(network_mod.STA_IF)
+    sta.active(True)
+    if hostname:
+        # MicroPython's `network.hostname()` is module-scoped on most ports;
+        # try both the modern and the per-iface API for compatibility.
+        try:
+            network_mod.hostname(hostname)
+        except (AttributeError, OSError):
+            try:
+                sta.config(hostname=hostname)
+            except (AttributeError, OSError, ValueError):
+                pass
+
+    sta.connect(ssid, password)
+
+    deadline_ms = timeout_s * 1000
+    waited_ms = 0
+    while waited_ms < deadline_ms:
+        if sta.isconnected():
+            return sta
+        _sleep_ms(_POLL_INTERVAL_MS)
+        waited_ms += _POLL_INTERVAL_MS
+    # Disable so we don't keep the radio in a half-associated state when we
+    # fall back to AP mode.
+    try:
+        sta.active(False)
+    except OSError:  # pragma: no cover - device-specific
+        pass
+    return None
+
+
+def _start_ap(network_mod, ssid, password):
+    """Bring up an open/WPA2 access point.  Returns the AP WLAN interface."""
+    ap = network_mod.WLAN(network_mod.AP_IF)
+    ap.active(True)
+    # ``config`` keyword names match MicroPython's network module.
+    try:
+        ap.config(essid=ssid, password=password)
+    except (TypeError, ValueError):
+        # Some ports expose the SSID as ``ssid`` rather than ``essid``.
+        ap.config(ssid=ssid, password=password)
+    return ap
+
+
+def connect(path=DEFAULT_CRED_PATH, timeout_s=DEFAULT_TIMEOUT_S, network_module=None):
+    """Bring up Wi-Fi according to :doc:`module behaviour <buddy.web.wifi>`.
+
+    Parameters
+    ----------
+    path : str
+        Path to the credentials JSON file on flash.
+    timeout_s : int
+        How long to wait for STA association before falling back to AP.
+    network_module : module, optional
+        Override for the ``network`` module — used by tests to inject a
+        mock.  Defaults to a real ``import network``.
+
+    Returns
+    -------
+    dict
+        ``{"mode": "sta"|"ap", "ssid": str, "ip": str|None, "wlan": iface}``.
+
+    Raises
+    ------
+    WiFiError
+        If the credentials file is missing/malformed *and* the AP fallback
+        also fails to start.
+    """
+    creds = load_credentials(path)
+    network_mod = network_module if network_module is not None else _import_network()
+
+    sta = _start_sta(
+        network_mod,
+        creds["ssid"],
+        creds["password"],
+        hostname=creds.get("hostname"),
+        timeout_s=timeout_s,
+    )
+    if sta is not None:
+        ip = _ifconfig_ip(sta)
+        return {"mode": "sta", "ssid": creds["ssid"], "ip": ip, "wlan": sta}
+
+    # Fallback: AP mode using the configured (or default) credentials.
+    ap_cfg = creds.get("ap_fallback") or {}
+    ap_ssid = ap_cfg.get("ssid", DEFAULT_AP_SSID)
+    ap_pwd = ap_cfg.get("password", DEFAULT_AP_PASSWORD)
+    try:
+        ap = _start_ap(network_mod, ap_ssid, ap_pwd)
+    except Exception as exc:
+        raise WiFiError("AP fallback failed: {}: {}".format(type(exc).__name__, exc))
+    ip = _ifconfig_ip(ap)
+    return {"mode": "ap", "ssid": ap_ssid, "ip": ip, "wlan": ap}
+
+
+def _ifconfig_ip(wlan):
+    """Return the IPv4 address from a WLAN interface, or ``None`` if unavailable."""
+    try:
+        cfg = wlan.ifconfig()
+    except (AttributeError, OSError):
+        return None
+    if cfg and len(cfg) >= 1:
+        return cfg[0]
+    return None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest>=7.0
 pytest-cov>=4.0
+microdot>=2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,50 @@ def _install_fake_machine():
     sys.modules["machine"] = mod
 
 
+# ---- fake `network` module --------------------------------------------------
+# `network` is MicroPython-only.  We register a default stub here so that
+# `import network` doesn't blow up when buddy.web.wifi is imported under
+# CPython.  Individual tests build per-test FakeWLAN instances and inject them
+# via the `network_module` argument to `wifi.connect(...)`, but this stub keeps
+# bare `import network` calls safe for any module-level imports added later.
+
+class _StubWLAN:
+    STA_IF = 0
+    AP_IF = 1
+
+    def __init__(self, *args, **kwargs):
+        self._connected = False
+        self._active = False
+
+    def active(self, value=None):
+        if value is None:
+            return self._active
+        self._active = bool(value)
+
+    def connect(self, ssid, password):  # pragma: no cover - replaced in tests
+        pass
+
+    def isconnected(self):  # pragma: no cover - replaced in tests
+        return False
+
+    def ifconfig(self):  # pragma: no cover - replaced in tests
+        return ("0.0.0.0", "0.0.0.0", "0.0.0.0", "0.0.0.0")
+
+    def config(self, **kwargs):  # pragma: no cover - replaced in tests
+        pass
+
+
+def _install_fake_network():
+    if "network" in sys.modules:
+        return
+    mod = types.ModuleType("network")
+    mod.STA_IF = 0
+    mod.AP_IF = 1
+    mod.WLAN = _StubWLAN
+    mod.hostname = lambda *a, **kw: None
+    sys.modules["network"] = mod
+
+
 def _install_time_shims():
     """The driver uses time.sleep_us / sleep_ms / ticks_ms / ticks_add / ticks_diff
     which are MicroPython extensions. Provide CPython-side stand-ins."""
@@ -83,6 +127,7 @@ def _install_time_shims():
 
 
 _install_fake_machine()
+_install_fake_network()
 _install_time_shims()
 
 # Make the package root importable so `import sts3215` works regardless of cwd.

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,0 +1,455 @@
+"""Integration tests for :mod:`buddy.web.server`.
+
+Endpoints are exercised via microdot's :class:`TestClient` against a fake
+:class:`Arm`.  The fake records every call so we can assert that each route
+delegates correctly without touching real servos.
+
+The WebSocket loop is blocking (it runs ``while True``) so we test its
+payload schema directly through :func:`buddy.web.server.state_payload`
+rather than spinning up an ASGI test harness.
+"""
+import asyncio
+from collections import OrderedDict
+
+import pytest
+
+from microdot.test_client import TestClient
+
+from buddy.web.server import (
+    ArmService,
+    create_app,
+    state_payload,
+    DEFAULT_STREAM_HZ,
+)
+
+
+# Microdot's TestClient methods are coroutines; wrap them so the rest of the
+# tests stay synchronous and easy to read.
+
+def _run(coro):
+    """Run *coro* on a fresh event loop and return its result.
+
+    ``asyncio.run`` would create + close a loop per call; on Python 3.12+
+    ``asyncio.get_event_loop`` no longer auto-creates one outside of
+    ``run``, so we make our own loop and reuse it for the lifetime of the
+    test process.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class SyncClient:
+    """Tiny sync facade around microdot.test_client.TestClient."""
+
+    def __init__(self, app):
+        self.app = app
+        self._client = TestClient(app)
+
+    def get(self, path, **kwargs):
+        return _run(self._client.get(path, **kwargs))
+
+    def post(self, path, body=None, **kwargs):
+        return _run(self._client.post(path, body=body, **kwargs))
+
+
+# ---- Fake arm --------------------------------------------------------------
+
+
+class FakeJointConfig:
+    def __init__(self, servo_id, min_angle=0.0, max_angle=360.0, is_gripper=False):
+        self.servo_id = servo_id
+        self.min_angle = min_angle
+        self.max_angle = max_angle
+        self.is_gripper = is_gripper
+        self.home = 180.0
+
+
+class FakeDriver:
+    """Stand-in for sts3215.STS3215; only ``read_temperature`` is exercised."""
+
+    def __init__(self):
+        self.temps = {}
+
+    def read_temperature(self, servo_id):
+        return self.temps.get(servo_id, 25)
+
+
+class FakeArm:
+    """Records every Arm method call so tests can introspect what happened."""
+
+    def __init__(self, names=("base", "shoulder", "gripper"), read_raises=False):
+        self._names = list(names)
+        self._joints = OrderedDict()
+        for i, n in enumerate(names):
+            self._joints[n] = FakeJointConfig(
+                servo_id=i + 1,
+                is_gripper=(n == "gripper"),
+            )
+        # Public stubs so the test can set the next read result.
+        self.next_read = [10.0 * (i + 1) for i in range(len(names))]
+        self.read_raises = read_raises
+        self.calls = []
+        self._driver = FakeDriver()
+
+    @property
+    def joint_names(self):
+        return list(self._names)
+
+    def joint(self, key):
+        if isinstance(key, str):
+            return self._joints[key]
+        return list(self._joints.values())[key]
+
+    def __len__(self):
+        return len(self._joints)
+
+    def read_all(self):
+        self.calls.append(("read_all",))
+        if self.read_raises:
+            raise RuntimeError("bus timeout")
+        return list(self.next_read)
+
+    def move_all(self, angles, speed=None, accel=None):
+        self.calls.append(("move_all", angles, speed, accel))
+
+    def enable_torque(self, key="all"):
+        self.calls.append(("enable_torque", key))
+
+    def disable_torque(self, key="all"):
+        self.calls.append(("disable_torque", key))
+
+    def gripper_open(self, speed=None, accel=None):
+        self.calls.append(("gripper_open", speed, accel))
+
+    def gripper_close(self, speed=None, accel=None):
+        self.calls.append(("gripper_close", speed, accel))
+
+    def home(self, speed=None, accel=None):
+        self.calls.append(("home", speed, accel))
+
+
+@pytest.fixture
+def fake_arm():
+    return FakeArm()
+
+
+@pytest.fixture
+def app_and_client(fake_arm):
+    app, _service = create_app(fake_arm)
+    return app, SyncClient(app)
+
+
+# ---- helpers ---------------------------------------------------------------
+
+def _json(resp):
+    """Microdot TestClient gives us a Response with a `.json` property."""
+    return resp.json
+
+
+# ---- /state ----------------------------------------------------------------
+
+
+def test_state_returns_full_snapshot(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.get("/state")
+    assert resp.status_code == 200
+    body = _json(resp)
+    assert "joints" in body
+    assert len(body["joints"]) == 3
+    j0 = body["joints"][0]
+    assert j0["name"] == "base"
+    assert j0["servo_id"] == 1
+    # Angle came from FakeArm.next_read[0] = 10.0
+    assert j0["angle"] == 10.0
+    assert j0["temperature"] == 25
+    # Gripper summary should point at the "gripper" entry.
+    assert body["gripper"]["name"] == "gripper"
+    assert body["error"] is None
+
+
+def test_state_payload_helper_matches_endpoint(fake_arm):
+    """The /ws stream and /state must emit the same schema — both go
+    through :func:`state_payload`.  Pin the keys so we don't accidentally
+    drift the schema."""
+    service = ArmService(fake_arm)
+    payload = state_payload(service)
+    assert set(payload) == {"joints", "gripper", "error"}
+    expected_joint_keys = {
+        "name", "servo_id", "min_angle", "max_angle",
+        "is_gripper", "angle", "temperature", "torque",
+    }
+    for j in payload["joints"]:
+        assert set(j) == expected_joint_keys
+
+
+def test_state_handles_read_failure_gracefully(fake_arm):
+    fake_arm.read_raises = True
+    app, _ = create_app(fake_arm)
+    client = SyncClient(app)
+    resp = client.get("/state")
+    assert resp.status_code == 200  # not 500 — we degrade not blow up
+    body = _json(resp)
+    assert body["error"] is not None
+    # Each joint's angle is None when the bulk read failed.
+    assert all(j["angle"] is None for j in body["joints"])
+
+
+# ---- /move (joint mode) ----------------------------------------------------
+
+
+def test_move_with_angles_list(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post(
+        "/move",
+        body={"angles": [10.0, 20.0, 30.0], "speed": 500, "accel": 25},
+    )
+    assert resp.status_code == 200
+    assert _json(resp) == {"ok": True, "mode": "joint"}
+    assert ("move_all", [10.0, 20.0, 30.0], 500, 25) in fake_arm.calls
+
+
+def test_move_with_angles_dict(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post("/move", body={"angles": {"shoulder": 90.0}})
+    assert resp.status_code == 200
+    # speed / accel default to None (server forwards defaults to Arm).
+    assert ("move_all", {"shoulder": 90.0}, None, None) in fake_arm.calls
+
+
+def test_move_invalid_angles_type_returns_400(app_and_client):
+    _, client = app_and_client
+    resp = client.post("/move", body={"angles": "not a list"})
+    assert resp.status_code == 400
+    assert _json(resp)["ok"] is False
+
+
+def test_move_with_no_body_keys_returns_400(app_and_client):
+    _, client = app_and_client
+    resp = client.post("/move", body={})
+    assert resp.status_code == 400
+
+
+def test_move_arm_failure_surfaces_as_500(fake_arm):
+    fake_arm.move_all = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("bus timeout"))
+    app, _ = create_app(fake_arm)
+    client = SyncClient(app)
+    resp = client.post("/move", body={"angles": [0, 0, 0]})
+    assert resp.status_code == 500
+    assert "bus timeout" in _json(resp)["error"]
+
+
+# ---- /move (Cartesian / IK adapter) ----------------------------------------
+
+
+def test_move_pose_without_ik_returns_501(app_and_client):
+    _, client = app_and_client
+    resp = client.post("/move", body={"pose": {"x": 0.1, "y": 0.0, "z": 0.2}})
+    assert resp.status_code == 501
+    assert "no IK adapter" in _json(resp)["error"]
+
+
+def test_move_pose_with_ik_adapter_routes_through(fake_arm):
+    captured = {}
+
+    def fake_ik(pose):
+        captured["pose"] = pose
+        return [11.0, 22.0, 33.0]
+
+    app, _ = create_app(fake_arm, pose_to_joints=fake_ik)
+    client = SyncClient(app)
+    resp = client.post("/move", body={"pose": {"x": 0.1, "y": 0.2, "z": 0.3}})
+    assert resp.status_code == 200
+    assert _json(resp) == {"ok": True, "mode": "pose"}
+    assert captured["pose"] == {"x": 0.1, "y": 0.2, "z": 0.3}
+    assert ("move_all", [11.0, 22.0, 33.0], None, None) in fake_arm.calls
+
+
+def test_move_pose_ik_exception_returns_500(fake_arm):
+    def boom(pose):
+        raise ValueError("unreachable")
+
+    app, _ = create_app(fake_arm, pose_to_joints=boom)
+    client = SyncClient(app)
+    resp = client.post("/move", body={"pose": {"x": 99}})
+    assert resp.status_code == 500
+    assert "IK error" in _json(resp)["error"]
+
+
+def test_move_pose_must_be_object(app_and_client):
+    _, client = app_and_client
+    resp = client.post("/move", body={"pose": [1, 2, 3]})
+    assert resp.status_code == 400
+
+
+# ---- /torque ---------------------------------------------------------------
+
+
+def test_torque_enable_all(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post("/torque", body={"enabled": True})
+    assert resp.status_code == 200
+    body = _json(resp)
+    assert body == {"ok": True, "enabled": True, "joint": "all"}
+    assert ("enable_torque", "all") in fake_arm.calls
+
+
+def test_torque_disable_named_joint(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post("/torque", body={"enabled": False, "joint": "shoulder"})
+    assert resp.status_code == 200
+    assert ("disable_torque", "shoulder") in fake_arm.calls
+
+
+def test_torque_disable_indexed_joint(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post("/torque", body={"enabled": False, "joint": 1})
+    assert resp.status_code == 200
+    assert ("disable_torque", 1) in fake_arm.calls
+
+
+def test_torque_missing_enabled_returns_400(app_and_client):
+    _, client = app_and_client
+    resp = client.post("/torque", body={})
+    assert resp.status_code == 400
+
+
+def test_torque_invalid_joint_key_returns_400(app_and_client):
+    _, client = app_and_client
+    resp = client.post("/torque", body={"enabled": True, "joint": True})
+    assert resp.status_code == 400
+
+
+def test_torque_failure_returns_500(fake_arm):
+    def boom(*a, **kw):
+        raise RuntimeError("packet error")
+
+    fake_arm.enable_torque = boom
+    app, _ = create_app(fake_arm)
+    client = SyncClient(app)
+    resp = client.post("/torque", body={"enabled": True})
+    assert resp.status_code == 500
+
+
+# ---- /gripper --------------------------------------------------------------
+
+
+def test_gripper_open(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post("/gripper", body={"action": "open"})
+    assert resp.status_code == 200
+    assert _json(resp) == {"ok": True, "action": "open"}
+    assert any(c[0] == "gripper_open" for c in fake_arm.calls)
+
+
+def test_gripper_close(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post("/gripper", body={"action": "close"})
+    assert resp.status_code == 200
+    assert any(c[0] == "gripper_close" for c in fake_arm.calls)
+
+
+def test_gripper_unknown_action_returns_400(app_and_client):
+    _, client = app_and_client
+    resp = client.post("/gripper", body={"action": "wiggle"})
+    assert resp.status_code == 400
+
+
+def test_gripper_arm_failure_returns_500(fake_arm):
+    fake_arm.gripper_open = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("nope"))
+    app, _ = create_app(fake_arm)
+    client = SyncClient(app)
+    resp = client.post("/gripper", body={"action": "open"})
+    assert resp.status_code == 500
+
+
+# ---- /home ----------------------------------------------------------------
+
+
+def test_home_with_no_body(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post("/home", body={})
+    assert resp.status_code == 200
+    assert _json(resp)["ok"] is True
+    assert any(c[0] == "home" for c in fake_arm.calls)
+
+
+def test_home_with_speed_accel(app_and_client, fake_arm):
+    _, client = app_and_client
+    resp = client.post("/home", body={"speed": 200, "accel": 5})
+    assert resp.status_code == 200
+    assert ("home", 200, 5) in fake_arm.calls
+
+
+def test_home_failure_returns_500(fake_arm):
+    fake_arm.home = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("stuck"))
+    app, _ = create_app(fake_arm)
+    client = SyncClient(app)
+    resp = client.post("/home", body={})
+    assert resp.status_code == 500
+
+
+# ---- ArmService directly --------------------------------------------------
+
+
+def test_service_state_handles_missing_driver_temperature():
+    """An Arm whose driver lacks read_temperature must still serialise OK."""
+    arm = FakeArm()
+    arm._driver = object()  # no read_temperature attribute
+    svc = ArmService(arm)
+    payload = svc.state()
+    for j in payload["joints"]:
+        assert j["temperature"] is None
+
+
+def test_service_state_with_no_driver_attribute():
+    """Some Arm-like duck types might omit ``_driver`` entirely."""
+    class NoDriverArm(FakeArm):
+        pass
+
+    arm = NoDriverArm()
+    delattr(arm, "_driver")
+    svc = ArmService(arm)
+    payload = svc.state()
+    assert payload["joints"][0]["temperature"] is None
+
+
+def test_service_gripper_unknown_action():
+    svc = ArmService(FakeArm())
+    _, err = svc.gripper("twist")
+    assert err is not None
+    assert "unknown gripper action" in err
+
+
+# ---- create_app return contract ------------------------------------------
+
+
+def test_create_app_returns_service_for_introspection(fake_arm):
+    app, service = create_app(fake_arm)
+    assert isinstance(service, ArmService)
+    # The service is also stashed on the app so middleware/handlers can
+    # reach it without a closure.
+    assert app.service is service
+    assert app.stream_hz == DEFAULT_STREAM_HZ
+
+
+def test_create_app_custom_stream_hz(fake_arm):
+    app, _ = create_app(fake_arm, stream_hz=10)
+    assert app.stream_hz == 10
+
+
+# ---- WS payload schema ---------------------------------------------------
+
+
+def test_ws_payload_shape_matches_state_endpoint(app_and_client, fake_arm):
+    """The WS broadcast loop calls ``state_payload(service)`` — verify the
+    schema directly so we don't have to spin up an ASGI test harness."""
+    _, client = app_and_client
+    rest = _json(client.get("/state"))
+    ws_payload = state_payload(client.app.service)
+    assert set(rest) == set(ws_payload)
+    assert len(rest["joints"]) == len(ws_payload["joints"])
+    for r, w in zip(rest["joints"], ws_payload["joints"]):
+        assert set(r) == set(w)

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -1,0 +1,236 @@
+"""Tests for :mod:`buddy.web.wifi`.
+
+A fake :mod:`network` module is injected per-test via the ``network_module``
+parameter of :func:`buddy.web.wifi.connect` so we can simulate STA failure /
+success and assert that the AP fallback engages cleanly under CPython — no
+real radios required.
+"""
+import json
+import types
+
+import pytest
+
+from buddy.web import wifi
+from buddy.web.wifi import WiFiError, connect, load_credentials
+
+
+# ---- in-memory fake `network` module ---------------------------------------
+
+
+class FakeWLAN:
+    """Records every call so tests can assert behaviour."""
+
+    def __init__(self, iface, isconnected_after=0, fail_active=False):
+        self.iface = iface
+        self.active_state = False
+        self.connected_to = None
+        self._calls_to_isconnected = 0
+        self._isconnected_after = isconnected_after
+        self.config_calls = []
+        self.ifconfig_value = ("192.168.1.42", "255.255.255.0", "192.168.1.1", "8.8.8.8")
+        self._fail_active = fail_active
+
+    def active(self, value=None):
+        if value is None:
+            return self.active_state
+        if self._fail_active and value is False:
+            raise OSError("simulated radio shutdown failure")
+        self.active_state = bool(value)
+
+    def connect(self, ssid, password):
+        self.connected_to = (ssid, password)
+
+    def isconnected(self):
+        self._calls_to_isconnected += 1
+        return self._calls_to_isconnected > self._isconnected_after
+
+    def ifconfig(self):
+        return self.ifconfig_value
+
+    def config(self, **kwargs):
+        self.config_calls.append(kwargs)
+
+
+def _make_network_module(sta_wlan, ap_wlan, hostname_supported=True):
+    """Build a stub ``network`` module that hands out the given WLAN fakes."""
+    mod = types.ModuleType("network")
+    mod.STA_IF = 0
+    mod.AP_IF = 1
+
+    instances = {}
+
+    def WLAN(iface):
+        if iface == 0:
+            instances.setdefault("sta", sta_wlan)
+            return sta_wlan
+        instances.setdefault("ap", ap_wlan)
+        return ap_wlan
+
+    mod.WLAN = WLAN
+    if hostname_supported:
+        mod.hostname = lambda name: instances.setdefault("hostname", name)
+    return mod
+
+
+# ---- credentials loader ----------------------------------------------------
+
+
+def test_load_credentials_round_trip(tmp_path):
+    p = tmp_path / "wifi.json"
+    p.write_text(json.dumps({"ssid": "x", "password": "y", "hostname": "buddy"}))
+    creds = load_credentials(str(p))
+    assert creds["ssid"] == "x"
+    assert creds["password"] == "y"
+    assert creds["hostname"] == "buddy"
+
+
+def test_load_credentials_missing_file_raises(tmp_path):
+    with pytest.raises(WiFiError, match="not found"):
+        load_credentials(str(tmp_path / "nope.json"))
+
+
+def test_load_credentials_bad_json_raises(tmp_path):
+    p = tmp_path / "wifi.json"
+    p.write_text("not json {{{")
+    with pytest.raises(WiFiError, match="not valid JSON"):
+        load_credentials(str(p))
+
+
+def test_load_credentials_rejects_non_object(tmp_path):
+    p = tmp_path / "wifi.json"
+    p.write_text(json.dumps(["a", "b"]))
+    with pytest.raises(WiFiError, match="JSON object"):
+        load_credentials(str(p))
+
+
+def test_load_credentials_requires_ssid_and_password(tmp_path):
+    p = tmp_path / "wifi.json"
+    p.write_text(json.dumps({"ssid": "only"}))
+    with pytest.raises(WiFiError, match="must include"):
+        load_credentials(str(p))
+
+
+# ---- STA happy-path --------------------------------------------------------
+
+
+def _write_creds(tmp_path, **extra):
+    body = {"ssid": "home", "password": "secret"}
+    body.update(extra)
+    p = tmp_path / "wifi.json"
+    p.write_text(json.dumps(body))
+    return str(p)
+
+
+def test_connect_sta_success_returns_sta_info(tmp_path):
+    sta = FakeWLAN(iface="sta", isconnected_after=0)
+    ap = FakeWLAN(iface="ap")
+    netmod = _make_network_module(sta, ap)
+    path = _write_creds(tmp_path, hostname="buddy")
+
+    result = connect(path=path, timeout_s=2, network_module=netmod)
+
+    assert result["mode"] == "sta"
+    assert result["ssid"] == "home"
+    assert result["ip"] == "192.168.1.42"
+    assert sta.connected_to == ("home", "secret")
+    assert sta.active_state is True
+    # AP must NOT have been activated when STA succeeds.
+    assert ap.active_state is False
+
+
+def test_connect_sta_falls_back_to_ap_on_timeout(tmp_path):
+    # never_connects → isconnected() always False
+    sta = FakeWLAN(iface="sta", isconnected_after=10_000)
+    ap = FakeWLAN(iface="ap")
+    netmod = _make_network_module(sta, ap)
+    path = _write_creds(tmp_path)
+
+    # Tiny timeout so the test runs fast.
+    result = connect(path=path, timeout_s=0, network_module=netmod)
+
+    assert result["mode"] == "ap"
+    # Default AP defaults are used when ap_fallback isn't in the file.
+    assert result["ssid"] == "buddy-arm"
+    assert ap.active_state is True
+    # STA radio should have been deactivated cleanly.
+    assert sta.active_state is False
+
+
+def test_connect_uses_custom_ap_fallback(tmp_path):
+    sta = FakeWLAN(iface="sta", isconnected_after=10_000)
+    ap = FakeWLAN(iface="ap")
+    netmod = _make_network_module(sta, ap)
+    path = _write_creds(
+        tmp_path,
+        ap_fallback={"ssid": "buddy-rescue", "password": "rescuepwd"},
+    )
+
+    result = connect(path=path, timeout_s=0, network_module=netmod)
+
+    assert result["mode"] == "ap"
+    assert result["ssid"] == "buddy-rescue"
+    # Either essid= or ssid= keyword is acceptable; both go through config().
+    assert ap.config_calls, "AP config() should have been called"
+    last = ap.config_calls[-1]
+    assert last.get("essid") == "buddy-rescue" or last.get("ssid") == "buddy-rescue"
+    assert last.get("password") == "rescuepwd"
+
+
+def test_connect_falls_through_when_sta_active_off_raises(tmp_path):
+    """If `sta.active(False)` raises after timeout, AP fallback must still
+    happen — we must not propagate device-specific shutdown errors."""
+    sta = FakeWLAN(iface="sta", isconnected_after=10_000, fail_active=True)
+    ap = FakeWLAN(iface="ap")
+    netmod = _make_network_module(sta, ap)
+    path = _write_creds(tmp_path)
+    result = connect(path=path, timeout_s=0, network_module=netmod)
+    assert result["mode"] == "ap"
+
+
+def test_connect_hostname_falls_back_to_iface_config(tmp_path):
+    """If module-level network.hostname() is missing, we should fall back to
+    sta.config(hostname=...)."""
+    sta = FakeWLAN(iface="sta", isconnected_after=0)
+    ap = FakeWLAN(iface="ap")
+    netmod = _make_network_module(sta, ap, hostname_supported=False)
+    path = _write_creds(tmp_path, hostname="buddy")
+
+    connect(path=path, timeout_s=2, network_module=netmod)
+
+    # config(hostname=...) must have been called as a fallback.
+    assert any("hostname" in call for call in sta.config_calls)
+
+
+def test_connect_propagates_ap_failure_as_wifi_error(tmp_path, monkeypatch):
+    """If even the AP fallback throws, surface it as WiFiError, not a stray
+    runtime exception."""
+    sta = FakeWLAN(iface="sta", isconnected_after=10_000)
+
+    class BoomWLAN(FakeWLAN):
+        def active(self, value=None):
+            if value is True:
+                raise RuntimeError("AP radio failed")
+            return super().active(value)
+
+    ap = BoomWLAN(iface="ap")
+    netmod = _make_network_module(sta, ap)
+    path = _write_creds(tmp_path)
+
+    with pytest.raises(WiFiError, match="AP fallback failed"):
+        connect(path=path, timeout_s=0, network_module=netmod)
+
+
+def test_connect_handles_missing_ifconfig(tmp_path):
+    sta = FakeWLAN(iface="sta", isconnected_after=0)
+    sta.ifconfig_value = ()  # falsy / empty — IP must come back as None
+    ap = FakeWLAN(iface="ap")
+    netmod = _make_network_module(sta, ap)
+    path = _write_creds(tmp_path)
+    result = connect(path=path, timeout_s=2, network_module=netmod)
+    assert result["ip"] is None
+
+
+def test_default_paths_constants_exposed():
+    # These must stay stable: they end up in user-facing docs and example file.
+    assert wifi.DEFAULT_CRED_PATH == "wifi_credentials.json"
+    assert wifi.DEFAULT_AP_SSID == "buddy-arm"

--- a/wifi_credentials.example.json
+++ b/wifi_credentials.example.json
@@ -1,0 +1,9 @@
+{
+  "ssid": "your-wifi-ssid",
+  "password": "your-wifi-password",
+  "hostname": "buddy",
+  "ap_fallback": {
+    "ssid": "buddy-arm",
+    "password": "buddy1234"
+  }
+}


### PR DESCRIPTION
Closes #5. Built on top of #2 (PR #10) — base will auto-update to `main` when #2 merges.

## Summary
- Adds `buddy.web` package: a microdot-based HTTP + WebSocket backend that wraps `buddy.arm.Arm` and exposes the control API expected by the web UI.
- Wi-Fi helper that reads credentials from a JSON file on flash and falls back to AP mode if STA association fails.
- 44 new tests with 89% coverage of `buddy.web` (well above the 80% bar). Full suite (110 tests) passes.

## Framework decision: microdot vs bare sockets
Picked **microdot** (recommended in the issue):

- Same `microdot` package on PyPI works on both CPython and MicroPython, so we can unit-test routes from CPython with `microdot.test_client.TestClient`.
- Provides routing, JSON helpers and a tiny WebSocket implementation in ~20 KB of flash and ~40 KB of RAM at runtime — well within Pico W / ESP32 budgets.
- Hand-rolling the same surface area on `socket`/`select` would be several hundred lines of HTTP/WS framing code and would block CPython unit testing.

Documented at the top of `buddy/web/server.py`.

## Endpoints
| Method | Path       | Body                                                    | Notes |
|--------|------------|---------------------------------------------------------|-------|
| GET    | `/state`   | —                                                       | per-joint angle / temperature / torque + gripper summary |
| POST   | `/move`    | `{"angles": [...] \| {...}}` or `{"pose": {...}}`        | Cartesian path requires the IK adapter — see below |
| POST   | `/torque`  | `{"enabled": bool, "joint": "all"\|name\|index}`         | |
| POST   | `/gripper` | `{"action": "open"\|"close"}`                            | |
| POST   | `/home`    | optional `{"speed": int, "accel": int}`                  | |
| WS     | `/ws`      | —                                                       | Streams `state_payload(...)` JSON at 20 Hz (configurable via `stream_hz=`) |

`state_payload(service)` is the single source of truth for both `/state` and `/ws` so the schema can never drift between the two.

## IK integration point left for #4
`create_app(arm, pose_to_joints=None, stream_hz=20)` accepts an optional `pose_to_joints` callable. When `/move` receives `{"pose": {...}}`:

- if `pose_to_joints` is `None` → returns **501** with `"no IK adapter configured (Phase 4 not yet wired in)"`
- otherwise the pose dict is forwarded; the callable returns a list of joint angles (or a `{name: angle}` dict) which is handed to `arm.move_all`.

Phase 4 just needs to import its IK function and pass it as `pose_to_joints=` — no changes to the server module are required.

## Wi-Fi flow
`buddy.web.wifi.connect(path="wifi_credentials.json", timeout_s=15)`:

1. Loads & validates the JSON credentials file (raises `WiFiError` with a helpful message on missing/malformed input).
2. Activates STA mode, calls `WLAN.connect(ssid, password)`, polls `isconnected()` for up to `timeout_s` seconds.
3. On success → returns `{"mode": "sta", "ssid": ..., "ip": ..., "wlan": iface}`.
4. On timeout → deactivates the STA radio and brings up an AP using the `ap_fallback` block in the JSON file (defaults `buddy-arm` / `buddy1234`).
5. If even the AP fails to start → raises `WiFiError("AP fallback failed: ...")`.

Hostname is set via `network.hostname()` if available, falling back to `wlan.config(hostname=...)` for older ports. The `network` module is imported lazily so tests can inject a stub via `network_module=` (mirrors the `machine` mock pattern in `tests/conftest.py`).

## Credentials hygiene
- `wifi_credentials.example.json` is committed as the template.
- `wifi_credentials.json` and the patterns `*.secret`, `*.secrets.json`, `secrets.py` are added to `.gitignore`.
- No real credentials are committed; tests build their own JSON via `tmp_path`.

## Deployment notes
On the device (Pico W / ESP32):

```
mip install microdot
mpremote cp -r buddy :
mpremote cp wifi_credentials.json :    # your real one, not the example
```

Then in `main.py`:

```python
from machine import UART, Pin
from sts3215 import STS3215
from buddy.arm import Arm
from buddy.web import server, wifi

uart = UART(0, baudrate=1_000_000, tx=Pin(0), rx=Pin(1))
arm = Arm(STS3215(uart, direction_pin=Pin(2)))
info = wifi.connect()                  # STA, AP fallback
print("network:", info["mode"], info["ip"])
server.run(arm, host="0.0.0.0", port=80)
```

## Test plan
- [x] `pytest tests/test_web_server.py tests/test_wifi.py --cov=buddy.web --cov-report=term-missing` → 44 passed, **89% coverage**
- [x] `pytest` (full suite) → 110 passed, no regressions
- [ ] Smoke-test on a real Pico W: hit `/state`, open a WS connection from the browser devtools, exercise `/move` and `/home`