### PR TITLE
Phase 7: CLI (REPL + web console)

### DIFF
--- a/buddy/cli.py
+++ b/buddy/cli.py
@@ -1,0 +1,264 @@
+"""Text command interface for the Buddy arm.
+
+Provides a small command parser usable from:
+
+* the MicroPython REPL over USB (via :func:`repl`), and
+* the web console (via the ``POST /cli`` endpoint in
+  :mod:`buddy.web.server`).
+
+Both paths share a single :func:`dispatch` entry point so that every
+command is parsed identically regardless of transport.
+
+Commands
+--------
+=================================  ==========================================
+``move J<n> <deg>``                Move joint *n* (1-based) to *deg* degrees.
+``pose <x> <y> <z> [pitch roll]`` IK move; pitch/roll default to 0.
+``home``                           Drive all joints to their home position.
+``torque on|off [J<n>]``           Enable/disable torque (all if no joint).
+``grip open|close``                Open or close the gripper.
+``read``                           Print current joint angles, positions,
+                                   temperatures.
+``help``                           List all commands with brief descriptions.
+=================================  ==========================================
+
+MicroPython constraints
+-----------------------
+* No ``argparse`` -- commands are parsed manually with ``str.split()``.
+* ``sys.stdin`` for REPL input (available in MicroPython).
+* Error messages are user-friendly strings, not tracebacks.
+"""
+
+try:
+    import sys
+except ImportError:  # pragma: no cover
+    import sys
+
+
+# ---------------------------------------------------------------------------
+# Help text
+# ---------------------------------------------------------------------------
+
+_HELP_TEXT = """\
+Buddy CLI commands:
+  move J<n> <deg>               Move joint n (1-based) to <deg> degrees
+  pose <x> <y> <z> [pitch roll] IK move (pitch/roll default to 0)
+  home                          Move all joints to home position
+  torque on|off [J<n>]          Enable/disable torque (all if no joint)
+  grip open|close               Open or close the gripper
+  read                          Print current joint angles and temperatures
+  help                          Show this help message"""
+
+
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+
+def _cmd_move(parts, arm, _kin):
+    """``move J<n> <deg>``"""
+    if len(parts) != 3:
+        return "Error: usage: move J<n> <degrees>"
+    joint_tok = parts[1]
+    if not joint_tok.upper().startswith("J"):
+        return "Error: joint must be specified as J<n> (e.g. J1)"
+    try:
+        joint_num = int(joint_tok[1:])
+    except ValueError:
+        return "Error: invalid joint number: {}".format(joint_tok)
+    if joint_num < 1 or joint_num > len(arm):
+        return "Error: joint number must be between 1 and {}".format(len(arm))
+    try:
+        deg = float(parts[2])
+    except ValueError:
+        return "Error: invalid angle: {}".format(parts[2])
+    try:
+        arm.move_joint(joint_num - 1, deg)
+    except Exception as exc:
+        return "Error: {}".format(exc)
+    return "OK: J{} moved to {:.1f} deg".format(joint_num, deg)
+
+
+def _cmd_pose(parts, arm, kin):
+    """``pose <x> <y> <z> [pitch roll]``"""
+    if kin is None:
+        return "Error: kinematics not available"
+    if len(parts) < 4:
+        return "Error: usage: pose <x> <y> <z> [pitch roll]"
+    if len(parts) > 6:
+        return "Error: usage: pose <x> <y> <z> [pitch roll]"
+    try:
+        coords = [float(v) for v in parts[1:]]
+    except ValueError:
+        return "Error: all pose values must be numbers"
+    # Pad pitch/roll with 0 if not provided.
+    while len(coords) < 5:
+        coords.append(0.0)
+    x, y, z, pitch, roll = coords
+    try:
+        angles = kin(x, y, z, pitch, roll)
+    except Exception as exc:
+        return "Error: {}".format(exc)
+    try:
+        arm.move_all(angles)
+    except Exception as exc:
+        return "Error: {}".format(exc)
+    return "OK: moved to pose ({:.1f}, {:.1f}, {:.1f}, {:.1f}, {:.1f})".format(
+        x, y, z, pitch, roll
+    )
+
+
+def _cmd_home(_parts, arm, _kin):
+    """``home``"""
+    try:
+        arm.home()
+    except Exception as exc:
+        return "Error: {}".format(exc)
+    return "OK: moved to home position"
+
+
+def _cmd_torque(parts, arm, _kin):
+    """``torque on|off [J<n>]``"""
+    if len(parts) < 2:
+        return "Error: usage: torque on|off [J<n>]"
+    action = parts[1].lower()
+    if action not in ("on", "off"):
+        return "Error: torque action must be 'on' or 'off'"
+    key = "all"
+    if len(parts) >= 3:
+        joint_tok = parts[2]
+        if not joint_tok.upper().startswith("J"):
+            return "Error: joint must be specified as J<n> (e.g. J1)"
+        try:
+            joint_num = int(joint_tok[1:])
+        except ValueError:
+            return "Error: invalid joint number: {}".format(joint_tok)
+        if joint_num < 1 or joint_num > len(arm):
+            return "Error: joint number must be between 1 and {}".format(len(arm))
+        key = joint_num - 1
+    try:
+        if action == "on":
+            arm.enable_torque(key)
+        else:
+            arm.disable_torque(key)
+    except Exception as exc:
+        return "Error: {}".format(exc)
+    target = "all joints" if key == "all" else "J{}".format(key + 1)
+    return "OK: torque {} for {}".format(action, target)
+
+
+def _cmd_grip(parts, arm, _kin):
+    """``grip open|close``"""
+    if len(parts) != 2:
+        return "Error: usage: grip open|close"
+    action = parts[1].lower()
+    if action == "open":
+        try:
+            arm.gripper_open()
+        except Exception as exc:
+            return "Error: {}".format(exc)
+        return "OK: gripper opened"
+    elif action == "close":
+        try:
+            arm.gripper_close()
+        except Exception as exc:
+            return "Error: {}".format(exc)
+        return "OK: gripper closed"
+    else:
+        return "Error: grip action must be 'open' or 'close'"
+
+
+def _cmd_read(_parts, arm, _kin):
+    """``read``"""
+    names = arm.joint_names
+    try:
+        angles = arm.read_all()
+    except Exception as exc:
+        return "Error: could not read joints: {}".format(exc)
+    lines = []
+    for i, name in enumerate(names):
+        angle = angles[i] if i < len(angles) else None
+        # Try to read temperature via the driver if available.
+        temp = None
+        driver = getattr(arm, "_driver", None)
+        if driver is not None and hasattr(driver, "read_temperature"):
+            joint_cfg = arm.joint(i)
+            try:
+                temp = driver.read_temperature(joint_cfg.servo_id)
+            except Exception:
+                pass
+        angle_str = "{:.1f} deg".format(angle) if angle is not None else "N/A"
+        temp_str = "{} C".format(temp) if temp is not None else "N/A"
+        lines.append("  J{} ({}): angle={}, temp={}".format(
+            i + 1, name, angle_str, temp_str
+        ))
+    return "Joint states:\n" + "\n".join(lines)
+
+
+def _cmd_help(_parts, _arm, _kin):
+    """``help``"""
+    return _HELP_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table
+# ---------------------------------------------------------------------------
+
+_COMMANDS = {
+    "move": _cmd_move,
+    "pose": _cmd_pose,
+    "home": _cmd_home,
+    "torque": _cmd_torque,
+    "grip": _cmd_grip,
+    "read": _cmd_read,
+    "help": _cmd_help,
+}
+
+
+def dispatch(line, arm, kinematics=None):
+    """Parse and execute a single CLI command.
+
+    Parameters
+    ----------
+    line : str
+        Raw command text (e.g. ``"move J1 90"``).
+    arm : buddy.arm.Arm
+        The arm instance to operate on.
+    kinematics : callable, optional
+        IK solver; signature ``(x, y, z, pitch, roll) -> list[float]``.
+        Required only for ``pose`` commands.
+
+    Returns
+    -------
+    str
+        Human-readable result or error message.
+    """
+    line = line.strip()
+    if not line:
+        return ""
+    parts = line.split()
+    cmd = parts[0].lower()
+    handler = _COMMANDS.get(cmd)
+    if handler is None:
+        return "Unknown command: {}. Type 'help' for available commands.".format(
+            parts[0]
+        )
+    return handler(parts, arm, kinematics)
+
+
+def repl(arm, kinematics=None):  # pragma: no cover - requires interactive stdin
+    """Interactive REPL loop for use from the MicroPython console.
+
+    Reads lines from ``sys.stdin`` via ``input()``, dispatches each one
+    through :func:`dispatch`, and prints the result.  Exits on EOF
+    (``Ctrl-D``) or ``KeyboardInterrupt`` (``Ctrl-C``).
+    """
+    print("Buddy CLI ready. Type 'help' for commands.")
+    while True:
+        try:
+            line = input("buddy> ")
+        except (EOFError, KeyboardInterrupt):
+            print("\nBye!")
+            break
+        result = dispatch(line, arm, kinematics=kinematics)
+        if result:
+            print(result)

--- a/buddy/web/server.py
+++ b/buddy/web/server.py
@@ -29,6 +29,8 @@ Endpoint summary
 ``POST /torque``      Body ``{"enabled": bool, "joint": "all"|name|index}``.
 ``POST /gripper``     Body ``{"action": "open"|"close"}``.
 ``POST /home``        No body. Drives the arm to its configured home pose.
+``POST /cli``         Body ``{"command": "..."}``; dispatches via the CLI
+                      parser and returns ``{"result": "..."}``.
 ``GET  /ws``          WebSocket stream — joint state JSON at ``stream_hz`` Hz
                       (default 20 Hz) for the 3D viewer.
 ====================  ===========================================================
@@ -223,7 +225,8 @@ def _request_json(req):
     return body
 
 
-def create_app(arm, pose_to_joints=None, stream_hz=DEFAULT_STREAM_HZ):
+def create_app(arm, pose_to_joints=None, stream_hz=DEFAULT_STREAM_HZ,
+               cli_dispatch=None):
     """Build and return a configured :class:`microdot.Microdot` app.
 
     Parameters
@@ -236,6 +239,10 @@ def create_app(arm, pose_to_joints=None, stream_hz=DEFAULT_STREAM_HZ):
         requests.  Defaults to ``None`` (Cartesian moves return 501).
     stream_hz : int
         WebSocket ``/ws`` broadcast rate.
+    cli_dispatch : callable, optional
+        ``(command_str, arm, kinematics=...) -> str`` CLI dispatcher.
+        When provided, a ``POST /cli`` endpoint is registered.  Pass
+        :func:`buddy.cli.dispatch` here to enable the web console.
 
     Returns
     -------
@@ -328,6 +335,27 @@ def create_app(arm, pose_to_joints=None, stream_hz=DEFAULT_STREAM_HZ):
         if err is not None:
             return {"ok": False, "error": err}, 500
         return {"ok": True}
+
+    # ---- CLI console endpoint -----------------------------------------------
+
+    @app.post("/cli")
+    def post_cli(req):
+        if cli_dispatch is None:
+            return {"ok": False, "error": "CLI not configured"}, 501
+        try:
+            body = _request_json(req)
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}, 400
+        command = body.get("command")
+        if not isinstance(command, str) or not command.strip():
+            return {"ok": False, "error": "'command' (non-empty string) required"}, 400
+        try:
+            result = cli_dispatch(command, service.arm, kinematics=service.pose_to_joints)
+        except Exception as exc:
+            return {"ok": False, "error": "{}: {}".format(type(exc).__name__, exc)}, 500
+        if result.startswith("Error:"):
+            return {"ok": False, "error": result}
+        return {"ok": True, "result": result}
 
     @app.route("/ws")
     @with_websocket

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,486 @@
+"""Tests for :mod:`buddy.cli` -- the text command parser.
+
+Every command is exercised via :func:`buddy.cli.dispatch` against a mock
+:class:`Arm` (and, where needed, a mock IK callable).  The test suite
+targets >= 80 % line coverage on ``buddy/cli.py``.
+"""
+from collections import OrderedDict
+
+import pytest
+
+from buddy.cli import dispatch, _HELP_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Fake Arm (mirrors the FakeArm from test_web_server.py)
+# ---------------------------------------------------------------------------
+
+class FakeJointConfig:
+    def __init__(self, servo_id, min_angle=0.0, max_angle=360.0, is_gripper=False):
+        self.servo_id = servo_id
+        self.min_angle = min_angle
+        self.max_angle = max_angle
+        self.is_gripper = is_gripper
+        self.home = 180.0
+
+
+class FakeDriver:
+    def __init__(self):
+        self.temps = {}
+
+    def read_temperature(self, servo_id):
+        return self.temps.get(servo_id, 25)
+
+
+class FakeArm:
+    """Records every method call for later assertion."""
+
+    def __init__(self, names=("base", "shoulder", "elbow", "wrist", "wrist_rot", "gripper")):
+        self._names = list(names)
+        self._joints = OrderedDict()
+        for i, n in enumerate(names):
+            self._joints[n] = FakeJointConfig(
+                servo_id=i + 1,
+                is_gripper=(n == "gripper"),
+            )
+        self.next_read = [10.0 * (i + 1) for i in range(len(names))]
+        self.calls = []
+        self._driver = FakeDriver()
+
+    @property
+    def joint_names(self):
+        return list(self._names)
+
+    def joint(self, key):
+        if isinstance(key, str):
+            return self._joints[key]
+        return list(self._joints.values())[key]
+
+    def __len__(self):
+        return len(self._joints)
+
+    def read_all(self):
+        self.calls.append(("read_all",))
+        return list(self.next_read)
+
+    def move_joint(self, key, angle_deg, speed=None, accel=None):
+        self.calls.append(("move_joint", key, angle_deg, speed, accel))
+
+    def move_all(self, angles, speed=None, accel=None):
+        self.calls.append(("move_all", angles, speed, accel))
+
+    def enable_torque(self, key="all"):
+        self.calls.append(("enable_torque", key))
+
+    def disable_torque(self, key="all"):
+        self.calls.append(("disable_torque", key))
+
+    def gripper_open(self, speed=None, accel=None):
+        self.calls.append(("gripper_open",))
+
+    def gripper_close(self, speed=None, accel=None):
+        self.calls.append(("gripper_close",))
+
+    def home(self, speed=None, accel=None):
+        self.calls.append(("home",))
+
+
+@pytest.fixture
+def arm():
+    return FakeArm()
+
+
+# ---------------------------------------------------------------------------
+# help
+# ---------------------------------------------------------------------------
+
+def test_help_lists_all_commands(arm):
+    result = dispatch("help", arm)
+    assert "move" in result
+    assert "pose" in result
+    assert "home" in result
+    assert "torque" in result
+    assert "grip" in result
+    assert "read" in result
+    assert "help" in result
+
+
+def test_help_returns_full_help_text(arm):
+    assert dispatch("help", arm) == _HELP_TEXT
+
+
+# ---------------------------------------------------------------------------
+# move
+# ---------------------------------------------------------------------------
+
+def test_move_valid_joint(arm):
+    result = dispatch("move J1 90", arm)
+    assert "OK" in result
+    assert "J1" in result
+    assert "90.0" in result
+    assert ("move_joint", 0, 90.0, None, None) in arm.calls
+
+
+def test_move_joint_case_insensitive(arm):
+    result = dispatch("move j3 45.5", arm)
+    assert "OK" in result
+    assert ("move_joint", 2, 45.5, None, None) in arm.calls
+
+
+def test_move_last_joint(arm):
+    result = dispatch("move J6 100", arm)
+    assert "OK" in result
+    assert ("move_joint", 5, 100.0, None, None) in arm.calls
+
+
+def test_move_missing_args(arm):
+    result = dispatch("move J1", arm)
+    assert "Error" in result
+    assert "usage" in result
+
+
+def test_move_too_many_args(arm):
+    result = dispatch("move J1 90 extra", arm)
+    assert "Error" in result
+
+
+def test_move_invalid_joint_format(arm):
+    result = dispatch("move X1 90", arm)
+    assert "Error" in result
+    assert "J<n>" in result
+
+
+def test_move_invalid_joint_number(arm):
+    result = dispatch("move Jabc 90", arm)
+    assert "Error" in result
+    assert "invalid joint number" in result
+
+
+def test_move_joint_out_of_range_zero(arm):
+    result = dispatch("move J0 90", arm)
+    assert "Error" in result
+    assert "between 1 and" in result
+
+
+def test_move_joint_out_of_range_high(arm):
+    result = dispatch("move J99 90", arm)
+    assert "Error" in result
+    assert "between 1 and" in result
+
+
+def test_move_invalid_angle(arm):
+    result = dispatch("move J1 abc", arm)
+    assert "Error" in result
+    assert "invalid angle" in result
+
+
+def test_move_arm_raises(arm):
+    def boom(*a, **kw):
+        raise RuntimeError("bus error")
+    arm.move_joint = boom
+    result = dispatch("move J1 90", arm)
+    assert "Error" in result
+    assert "bus error" in result
+
+
+# ---------------------------------------------------------------------------
+# pose
+# ---------------------------------------------------------------------------
+
+def test_pose_xyz_only(arm):
+    def fake_ik(x, y, z, pitch, roll):
+        return [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
+
+    result = dispatch("pose 100 200 300", arm, kinematics=fake_ik)
+    assert "OK" in result
+    assert "100.0" in result
+    assert ("move_all", [10.0, 20.0, 30.0, 40.0, 50.0, 60.0], None, None) in arm.calls
+
+
+def test_pose_with_pitch(arm):
+    def fake_ik(x, y, z, pitch, roll):
+        assert pitch == 45.0
+        assert roll == 0.0
+        return [0.0] * 6
+
+    result = dispatch("pose 10 20 30 45", arm, kinematics=fake_ik)
+    assert "OK" in result
+
+
+def test_pose_with_pitch_and_roll(arm):
+    def fake_ik(x, y, z, pitch, roll):
+        assert pitch == 45.0
+        assert roll == 90.0
+        return [0.0] * 6
+
+    result = dispatch("pose 10 20 30 45 90", arm, kinematics=fake_ik)
+    assert "OK" in result
+    assert "45.0" in result
+    assert "90.0" in result
+
+
+def test_pose_no_kinematics(arm):
+    result = dispatch("pose 10 20 30", arm, kinematics=None)
+    assert "Error" in result
+    assert "kinematics not available" in result
+
+
+def test_pose_too_few_args(arm):
+    result = dispatch("pose 10 20", arm, kinematics=lambda *a: [0] * 6)
+    assert "Error" in result
+    assert "usage" in result
+
+
+def test_pose_too_many_args(arm):
+    result = dispatch("pose 10 20 30 40 50 60", arm, kinematics=lambda *a: [0] * 6)
+    assert "Error" in result
+    assert "usage" in result
+
+
+def test_pose_non_numeric_args(arm):
+    result = dispatch("pose abc 20 30", arm, kinematics=lambda *a: [0] * 6)
+    assert "Error" in result
+    assert "numbers" in result
+
+
+def test_pose_ik_raises(arm):
+    def bad_ik(x, y, z, pitch, roll):
+        raise ValueError("unreachable target")
+
+    result = dispatch("pose 10 20 30", arm, kinematics=bad_ik)
+    assert "Error" in result
+    assert "unreachable target" in result
+
+
+def test_pose_move_all_raises(arm):
+    def ok_ik(x, y, z, pitch, roll):
+        return [0.0] * 6
+
+    def bad_move(*a, **kw):
+        raise RuntimeError("bus error")
+
+    arm.move_all = bad_move
+    result = dispatch("pose 10 20 30", arm, kinematics=ok_ik)
+    assert "Error" in result
+    assert "bus error" in result
+
+
+# ---------------------------------------------------------------------------
+# home
+# ---------------------------------------------------------------------------
+
+def test_home(arm):
+    result = dispatch("home", arm)
+    assert "OK" in result
+    assert "home" in result
+    assert ("home",) in arm.calls
+
+
+def test_home_raises(arm):
+    arm.home = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("stuck"))
+    result = dispatch("home", arm)
+    assert "Error" in result
+    assert "stuck" in result
+
+
+# ---------------------------------------------------------------------------
+# torque
+# ---------------------------------------------------------------------------
+
+def test_torque_on_all(arm):
+    result = dispatch("torque on", arm)
+    assert "OK" in result
+    assert "torque on" in result
+    assert "all joints" in result
+    assert ("enable_torque", "all") in arm.calls
+
+
+def test_torque_off_all(arm):
+    result = dispatch("torque off", arm)
+    assert "OK" in result
+    assert "torque off" in result
+    assert ("disable_torque", "all") in arm.calls
+
+
+def test_torque_on_specific_joint(arm):
+    result = dispatch("torque on J2", arm)
+    assert "OK" in result
+    assert "J2" in result
+    assert ("enable_torque", 1) in arm.calls
+
+
+def test_torque_off_specific_joint(arm):
+    result = dispatch("torque off J3", arm)
+    assert "OK" in result
+    assert ("disable_torque", 2) in arm.calls
+
+
+def test_torque_case_insensitive(arm):
+    result = dispatch("torque ON j1", arm)
+    assert "OK" in result
+    assert ("enable_torque", 0) in arm.calls
+
+
+def test_torque_missing_action(arm):
+    result = dispatch("torque", arm)
+    assert "Error" in result
+    assert "usage" in result
+
+
+def test_torque_invalid_action(arm):
+    result = dispatch("torque maybe", arm)
+    assert "Error" in result
+    assert "'on' or 'off'" in result
+
+
+def test_torque_invalid_joint_format(arm):
+    result = dispatch("torque on X1", arm)
+    assert "Error" in result
+    assert "J<n>" in result
+
+
+def test_torque_invalid_joint_number(arm):
+    result = dispatch("torque on Jabc", arm)
+    assert "Error" in result
+    assert "invalid joint number" in result
+
+
+def test_torque_joint_out_of_range(arm):
+    result = dispatch("torque on J99", arm)
+    assert "Error" in result
+    assert "between 1 and" in result
+
+
+def test_torque_raises(arm):
+    arm.enable_torque = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("nope"))
+    result = dispatch("torque on", arm)
+    assert "Error" in result
+    assert "nope" in result
+
+
+# ---------------------------------------------------------------------------
+# grip
+# ---------------------------------------------------------------------------
+
+def test_grip_open(arm):
+    result = dispatch("grip open", arm)
+    assert "OK" in result
+    assert "opened" in result
+    assert ("gripper_open",) in arm.calls
+
+
+def test_grip_close(arm):
+    result = dispatch("grip close", arm)
+    assert "OK" in result
+    assert "closed" in result
+    assert ("gripper_close",) in arm.calls
+
+
+def test_grip_invalid_action(arm):
+    result = dispatch("grip wiggle", arm)
+    assert "Error" in result
+    assert "'open' or 'close'" in result
+
+
+def test_grip_missing_action(arm):
+    result = dispatch("grip", arm)
+    assert "Error" in result
+    assert "usage" in result
+
+
+def test_grip_too_many_args(arm):
+    result = dispatch("grip open close", arm)
+    assert "Error" in result
+
+
+def test_grip_open_raises(arm):
+    arm.gripper_open = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("jam"))
+    result = dispatch("grip open", arm)
+    assert "Error" in result
+    assert "jam" in result
+
+
+def test_grip_close_raises(arm):
+    arm.gripper_close = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("jam"))
+    result = dispatch("grip close", arm)
+    assert "Error" in result
+    assert "jam" in result
+
+
+# ---------------------------------------------------------------------------
+# read
+# ---------------------------------------------------------------------------
+
+def test_read_shows_all_joints(arm):
+    result = dispatch("read", arm)
+    assert "Joint states:" in result
+    # One line per joint (6 joints)
+    for i, name in enumerate(arm.joint_names):
+        assert "J{}".format(i + 1) in result
+        assert name in result
+    assert "deg" in result
+    assert "temp" in result
+
+
+def test_read_shows_temperatures(arm):
+    arm._driver.temps = {1: 30, 2: 35}
+    result = dispatch("read", arm)
+    assert "30 C" in result
+    assert "25 C" in result  # default for others
+
+
+def test_read_without_driver(arm):
+    arm._driver = None
+    result = dispatch("read", arm)
+    assert "N/A" in result  # temp is N/A
+    assert "Joint states:" in result
+
+
+def test_read_without_read_temperature(arm):
+    arm._driver = object()  # no read_temperature
+    result = dispatch("read", arm)
+    assert "N/A" in result
+
+
+def test_read_raises(arm):
+    def boom():
+        raise RuntimeError("bus timeout")
+    arm.read_all = boom
+    result = dispatch("read", arm)
+    assert "Error" in result
+    assert "bus timeout" in result
+
+
+# ---------------------------------------------------------------------------
+# Unknown / empty commands
+# ---------------------------------------------------------------------------
+
+def test_unknown_command(arm):
+    result = dispatch("dance", arm)
+    assert "Unknown command" in result
+    assert "dance" in result
+    assert "help" in result
+
+
+def test_empty_string(arm):
+    result = dispatch("", arm)
+    assert result == ""
+
+
+def test_whitespace_only(arm):
+    result = dispatch("   ", arm)
+    assert result == ""
+
+
+def test_command_with_extra_whitespace(arm):
+    result = dispatch("  home  ", arm)
+    assert "OK" in result
+
+
+# ---------------------------------------------------------------------------
+# dispatch preserves original case in unknown-command messages
+# ---------------------------------------------------------------------------
+
+def test_unknown_preserves_original_token(arm):
+    result = dispatch("Dance", arm)
+    assert "Dance" in result

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -453,3 +453,92 @@ def test_ws_payload_shape_matches_state_endpoint(app_and_client, fake_arm):
     assert len(rest["joints"]) == len(ws_payload["joints"])
     for r, w in zip(rest["joints"], ws_payload["joints"]):
         assert set(r) == set(w)
+
+
+# ---- /cli endpoint -------------------------------------------------------
+
+def _fake_dispatch(command, arm, kinematics=None):
+    """Simple stand-in for buddy.cli.dispatch."""
+    if command.strip() == "home":
+        arm.home()
+        return "OK: moved to home position"
+    if command.strip().startswith("Error"):
+        return "Error: simulated error"
+    return "OK: dispatched"
+
+
+@pytest.fixture
+def cli_app_and_client(fake_arm):
+    app, _service = create_app(fake_arm, cli_dispatch=_fake_dispatch)
+    return app, SyncClient(app)
+
+
+def test_cli_endpoint_dispatches_command(cli_app_and_client, fake_arm):
+    _, client = cli_app_and_client
+    resp = client.post("/cli", body={"command": "home"})
+    assert resp.status_code == 200
+    body = _json(resp)
+    assert body["ok"] is True
+    assert "home" in body["result"]
+    assert any(c[0] == "home" for c in fake_arm.calls)
+
+
+def test_cli_endpoint_returns_ok_result(cli_app_and_client):
+    _, client = cli_app_and_client
+    resp = client.post("/cli", body={"command": "something"})
+    assert resp.status_code == 200
+    body = _json(resp)
+    assert body["ok"] is True
+    assert body["result"] == "OK: dispatched"
+
+
+def test_cli_endpoint_returns_error_on_error_result(cli_app_and_client):
+    _, client = cli_app_and_client
+    resp = client.post("/cli", body={"command": "Error please"})
+    body = _json(resp)
+    assert body["ok"] is False
+    assert "error" in body
+
+
+def test_cli_endpoint_missing_command(cli_app_and_client):
+    _, client = cli_app_and_client
+    resp = client.post("/cli", body={})
+    assert resp.status_code == 400
+    body = _json(resp)
+    assert body["ok"] is False
+    assert "command" in body["error"].lower()
+
+
+def test_cli_endpoint_empty_command(cli_app_and_client):
+    _, client = cli_app_and_client
+    resp = client.post("/cli", body={"command": "   "})
+    assert resp.status_code == 400
+
+
+def test_cli_endpoint_command_not_string(cli_app_and_client):
+    _, client = cli_app_and_client
+    resp = client.post("/cli", body={"command": 123})
+    assert resp.status_code == 400
+
+
+def test_cli_endpoint_not_configured(app_and_client):
+    """When cli_dispatch is None (not passed), /cli returns 501."""
+    _, client = app_and_client
+    resp = client.post("/cli", body={"command": "home"})
+    assert resp.status_code == 501
+    body = _json(resp)
+    assert body["ok"] is False
+    assert "not configured" in body["error"]
+
+
+def test_cli_endpoint_dispatch_exception(fake_arm):
+    """If the dispatch function itself raises, the endpoint returns 500."""
+    def boom(command, arm, kinematics=None):
+        raise RuntimeError("unexpected crash")
+
+    app, _ = create_app(fake_arm, cli_dispatch=boom)
+    client = SyncClient(app)
+    resp = client.post("/cli", body={"command": "home"})
+    assert resp.status_code == 500
+    body = _json(resp)
+    assert "unexpected crash" in body["error"]


### PR DESCRIPTION
## Summary

- Add `buddy/cli.py` with a text command parser (`dispatch()` + `repl()`) supporting 7 commands: `move J<n> <deg>`, `pose <x> <y> <z> [pitch roll]`, `home`, `torque on|off [J<n>]`, `grip open|close`, `read`, and `help`
- Add `POST /cli` endpoint to `buddy/web/server.py` so the web frontend console can send commands through the same parser
- Add comprehensive test suite (`tests/test_cli.py` with 52 tests, 8 new tests in `tests/test_web_server.py`)

## Design decisions

- The `dispatch(line, arm, kinematics=None)` function is the single entry point for both REPL and web console, ensuring identical parsing
- Joint numbers are 1-based in user-facing commands (J1..J6) but converted to 0-based internally
- The `kinematics` parameter accepts a callable `(x, y, z, pitch, roll) -> angles` so it works with `buddy.kinematics.inverse` or any compatible solver
- The `/cli` endpoint accepts `{"command": "..."}` and returns `{"ok": true, "result": "..."}` or `{"ok": false, "error": "..."}`, detecting errors by checking if the dispatch result starts with "Error:"
- When `cli_dispatch` is not passed to `create_app()`, `/cli` returns 501 (Not Implemented) for backwards compatibility

## Test coverage

- `buddy/cli.py`: **98%** (130 statements, 2 missed -- only the interactive `repl()` stdin loop)
- 52 tests in `test_cli.py` covering all commands, edge cases, malformed input, and error propagation
- 8 tests in `test_web_server.py` covering the `/cli` endpoint (success, error results, missing/empty/non-string command, unconfigured, dispatch exception)
- Full suite: **231 tests passing**, zero regressions

## Test plan

- [x] All 7 commands parse and dispatch correctly
- [x] Malformed input returns helpful error messages (not crashes)
- [x] `help` lists all available commands
- [x] `move` with invalid joint number returns error
- [x] `pose` with unreachable target returns the error from kinematics
- [x] `torque on/off` with and without joint specifier
- [x] `grip open/close`
- [x] `read` returns formatted state string with angles and temperatures
- [x] Unknown commands return "Unknown command" message
- [x] `POST /cli` endpoint integration tested
- [x] >= 80% coverage on `cli.py` (achieved 98%)

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)